### PR TITLE
Capture provider thinking streams in chat

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,20 +2,19 @@
 
 
 import React, { useState, useCallback, useMemo, useEffect, FormEvent, useRef } from 'react';
-import type { Chat } from "@google/genai";
-import { HarmCategory, HarmBlockThreshold } from "@google/genai";
 import { ProgressBar } from './components/ui/ProgressBar';
 import { Tabs } from './components/ui/Tabs';
 import { ReportModal } from './components/modals/ReportModal';
 import { ChatSettingsModal } from './components/modals/ChatSettingsModal';
 import { XCircleIcon } from './components/icons/XCircleIcon';
 import { useStarfield } from './hooks/useStarfield';
-import type { ProcessedOutput, ProgressUpdate, AppState, ProcessingError, Mode, RewriteLength, SummaryFormat, ReasoningSettings, ScaffolderSettings, RequestSplitterSettings, PromptEnhancerSettings, AgentDesignerSettings, ChatSettings, ChatMessage, SavedPrompt } from './types';
-import { INITIAL_PROGRESS, INITIAL_REASONING_SETTINGS, INITIAL_SCAFFOLDER_SETTINGS, INITIAL_REQUEST_SPLITTER_SETTINGS, INITIAL_PROMPT_ENHANCER_SETTINGS, INITIAL_AGENT_DESIGNER_SETTINGS, INITIAL_CHAT_SETTINGS } from './constants';
+import type { ProcessedOutput, ProgressUpdate, AppState, ProcessingError, Mode, RewriteLength, SummaryFormat, ReasoningSettings, ScaffolderSettings, RequestSplitterSettings, PromptEnhancerSettings, AgentDesignerSettings, ChatSettings, ChatMessage, SavedPrompt, AIProviderSettings } from './types';
+import { INITIAL_PROGRESS, INITIAL_REASONING_SETTINGS, INITIAL_SCAFFOLDER_SETTINGS, INITIAL_REQUEST_SPLITTER_SETTINGS, INITIAL_PROMPT_ENHANCER_SETTINGS, INITIAL_AGENT_DESIGNER_SETTINGS, INITIAL_CHAT_SETTINGS, INITIAL_AI_PROVIDER_SETTINGS, DEFAULT_PROVIDER_MODELS } from './constants';
 import { SUMMARY_FORMAT_OPTIONS } from './data/summaryFormats';
 import { TABS, DESCRIPTION_TEXT, getButtonText } from './constants/uiConstants';
 import { handleSubmission } from './services/submissionService';
-import { ai } from './services/geminiService';
+import { setActiveProviderConfig, sendChatMessage } from './services/geminiService';
+import { AI_PROVIDERS, fetchModelsForProvider, getProviderLabel } from './services/providerRegistry';
 import { fileToGenerativePart } from './utils/fileUtils';
 import {
   downloadReasoningArtifact,
@@ -33,12 +32,8 @@ import { StopButton } from './components/ui/StopButton';
 import { ResultsViewer } from './components/layouts/ResultsViewer';
 
 
-const safetySettings = [
-    { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE },
-    { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE },
-    { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE },
-    { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE },
-];
+const PROVIDER_SETTINGS_STORAGE_KEY = 'ai_content_suite_provider_settings';
+const CHAT_SETTINGS_STORAGE_KEY = 'ai_content_suite_chat_settings';
 
 const App: React.FC = () => {
   // --- STATE MANAGEMENT ---
@@ -70,12 +65,12 @@ const App: React.FC = () => {
   const [requestSplitterSettings, setRequestSplitterSettings] = useState<RequestSplitterSettings>(INITIAL_REQUEST_SPLITTER_SETTINGS);
   const [promptEnhancerSettings, setPromptEnhancerSettings] = useState<PromptEnhancerSettings>(INITIAL_PROMPT_ENHANCER_SETTINGS);
   const [agentDesignerSettings, setAgentDesignerSettings] = useState<AgentDesignerSettings>(INITIAL_AGENT_DESIGNER_SETTINGS);
-  
+
   // --- CHAT-SPECIFIC STATE ---
   const [chatSettings, setChatSettings] = useState<ChatSettings>(INITIAL_CHAT_SETTINGS);
+  const [aiProviderSettings, setAiProviderSettings] = useState<AIProviderSettings>(INITIAL_AI_PROVIDER_SETTINGS);
   const [savedPrompts, setSavedPrompts] = useState<SavedPrompt[]>([]);
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
-  const [chatSession, setChatSession] = useState<Chat | null>(null);
   const [isStreamingResponse, setIsStreamingResponse] = useState(false);
   const [chatInput, setChatInput] = useState('');
   const [chatFiles, setChatFiles] = useState<File[] | null>(null);
@@ -84,8 +79,88 @@ const App: React.FC = () => {
 
   // --- HOOKS ---
   useStarfield('space-background');
-  
+
   // --- EFFECTS ---
+  useEffect(() => {
+    try {
+      const savedSettings = localStorage.getItem(CHAT_SETTINGS_STORAGE_KEY);
+      if (savedSettings) {
+        const parsed = JSON.parse(savedSettings);
+        if (parsed && typeof parsed === 'object') {
+          const defaults = INITIAL_CHAT_SETTINGS.vectorStore;
+          const parsedVectorStore = parsed.vectorStore && typeof parsed.vectorStore === 'object' ? parsed.vectorStore : {};
+          const mergedVectorStore = defaults
+            ? {
+                ...defaults,
+                ...parsedVectorStore,
+                embedding: {
+                  ...defaults.embedding,
+                  ...(parsedVectorStore.embedding ?? {}),
+                },
+              }
+            : parsedVectorStore;
+
+          setChatSettings({
+            ...INITIAL_CHAT_SETTINGS,
+            ...parsed,
+            vectorStore: mergedVectorStore,
+          });
+        }
+      }
+    } catch (error) {
+      console.error('Failed to load chat settings from local storage:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(PROVIDER_SETTINGS_STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        const availableProviders = new Set(AI_PROVIDERS.map(provider => provider.id));
+        const providerId = (availableProviders.has(parsed.selectedProvider)
+          ? parsed.selectedProvider
+          : INITIAL_AI_PROVIDER_SETTINGS.selectedProvider) as AIProviderSettings['selectedProvider'];
+        const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? DEFAULT_PROVIDER_MODELS[INITIAL_AI_PROVIDER_SETTINGS.selectedProvider];
+        const selectedModel = typeof parsed.selectedModel === 'string' && parsed.selectedModel.trim() !== ''
+          ? parsed.selectedModel
+          : fallbackModel;
+        const apiKeys = parsed.apiKeys && typeof parsed.apiKeys === 'object' && parsed.apiKeys !== null ? parsed.apiKeys : {};
+        setAiProviderSettings({ selectedProvider: providerId, selectedModel, apiKeys });
+      }
+    } catch (e) {
+      console.error('Failed to load provider settings from local storage:', e);
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(PROVIDER_SETTINGS_STORAGE_KEY, JSON.stringify(aiProviderSettings));
+    } catch (e) {
+      console.error('Failed to save provider settings to local storage:', e);
+    }
+  }, [aiProviderSettings]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(CHAT_SETTINGS_STORAGE_KEY, JSON.stringify(chatSettings));
+    } catch (error) {
+      console.error('Failed to save chat settings to local storage:', error);
+    }
+  }, [chatSettings]);
+
+  useEffect(() => {
+    const apiKey = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
+    const model = aiProviderSettings.selectedModel && aiProviderSettings.selectedModel.trim() !== ''
+      ? aiProviderSettings.selectedModel
+      : DEFAULT_PROVIDER_MODELS[aiProviderSettings.selectedProvider];
+    setActiveProviderConfig({
+      providerId: aiProviderSettings.selectedProvider,
+      model,
+      apiKey,
+    });
+  }, [aiProviderSettings]);
+
   // Load saved prompts from local storage on mount
   useEffect(() => {
     try {
@@ -107,13 +182,6 @@ const App: React.FC = () => {
     }
   }, [savedPrompts]);
 
-  // Effect to reset chat session when system prompt changes
-  useEffect(() => {
-    if (activeMode === 'chat') {
-        setChatSession(null); // Force re-initialization on next message
-    }
-  }, [chatSettings.systemInstruction, activeMode]);
-  
   // Effect to handle state changes for cancellation
   useEffect(() => {
     if (appState === 'cancelled') {
@@ -161,6 +229,50 @@ const App: React.FC = () => {
     isStreamingResponse,
   ]);
 
+  const activeProviderLabel = useMemo(
+    () => getProviderLabel(aiProviderSettings.selectedProvider),
+    [aiProviderSettings.selectedProvider],
+  );
+
+  const activeProviderInfo = useMemo(
+    () => AI_PROVIDERS.find(provider => provider.id === aiProviderSettings.selectedProvider),
+    [aiProviderSettings.selectedProvider],
+  );
+
+  const activeModelName = useMemo(() => {
+    const trimmed = aiProviderSettings.selectedModel?.trim();
+    if (trimmed && trimmed.length > 0) {
+      return trimmed;
+    }
+    return DEFAULT_PROVIDER_MODELS[aiProviderSettings.selectedProvider] ?? '';
+  }, [aiProviderSettings]);
+
+  const isApiKeyConfigured = useMemo(() => {
+    const key = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
+    return typeof key === 'string' && key.trim() !== '';
+  }, [aiProviderSettings]);
+
+  const providerStatusText = useMemo(() => {
+    if (!activeProviderInfo) return 'Provider status unavailable';
+    if (activeProviderInfo.requiresApiKey) {
+      return isApiKeyConfigured ? 'API key saved' : 'API key required';
+    }
+    return 'API key optional';
+  }, [activeProviderInfo, isApiKeyConfigured]);
+
+  const providerStatusTone = useMemo(() => {
+    if (!activeProviderInfo) return 'text-destructive';
+    if (activeProviderInfo.requiresApiKey) {
+      return isApiKeyConfigured ? 'text-emerald-400' : 'text-destructive';
+    }
+    return 'text-text-secondary';
+  }, [activeProviderInfo, isApiKeyConfigured]);
+
+  const providerSummaryText = useMemo(
+    () => (activeModelName ? `${activeProviderLabel} • ${activeModelName}` : activeProviderLabel),
+    [activeProviderLabel, activeModelName],
+  );
+
   const buttonText = useMemo(() => {
     return getButtonText(
       activeMode,
@@ -205,7 +317,6 @@ const App: React.FC = () => {
     setAgentDesignerSettings(INITIAL_AGENT_DESIGNER_SETTINGS);
     setChatSettings(INITIAL_CHAT_SETTINGS);
     setChatHistory([]);
-    setChatSession(null);
     setIsStreamingResponse(false);
     setChatInput('');
     setChatFiles(null);
@@ -249,65 +360,82 @@ const App: React.FC = () => {
 
   const handleChatSubmit = useCallback(async (e?: FormEvent<HTMLFormElement>) => {
     e?.preventDefault();
-    if (!ai || !canSubmit) return;
+    if (!canSubmit) return;
 
-    setIsStreamingResponse(true);
-    setError(null);
-
-    let currentChatSession = chatSession;
-    if (!currentChatSession) {
-        // Fix: Moved `safetySettings` into the `config` object as it's not a top-level parameter for `ai.chats.create`.
-        const newChat: Chat = ai.chats.create({
-            model: 'gemini-2.5-flash',
-            history: chatHistory,
-            config: {
-                systemInstruction: chatSettings.systemInstruction,
-                safetySettings: safetySettings,
-            },
-        });
-        setChatSession(newChat);
-        currentChatSession = newChat;
+    const providerInfo = AI_PROVIDERS.find(provider => provider.id === aiProviderSettings.selectedProvider);
+    const apiKeyForProvider = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
+    if (providerInfo?.requiresApiKey && (!apiKeyForProvider || apiKeyForProvider.trim() === '')) {
+      setError({ message: `${providerInfo.label} requires an API key. Please add it in settings before starting a chat.` });
+      return;
     }
+
+    const historyBeforeMessage = chatHistory;
+    const trimmedInput = chatInput.trim();
 
     try {
-        const fileParts = chatFiles ? await Promise.all(chatFiles.map(fileToGenerativePart)) : [];
-        const textPart = chatInput.trim() ? [{ text: chatInput }] : [];
-        const userMessageParts = [...fileParts, ...textPart];
+      const fileParts = chatFiles ? await Promise.all(chatFiles.map(fileToGenerativePart)) : [];
+      const textParts = trimmedInput ? [{ text: trimmedInput }] : [];
+      const userMessageParts = [...fileParts, ...textParts];
 
-        if (userMessageParts.length === 0) {
-            setIsStreamingResponse(false);
-            return;
+      if (userMessageParts.length === 0) {
+        return;
+      }
+
+      const userMessage: ChatMessage = { role: 'user', parts: userMessageParts };
+
+      setChatHistory(prev => [...prev, userMessage, { role: 'model', parts: [{ text: '' }], thinking: [] }]);
+      setChatInput('');
+      setChatFiles(null);
+      setIsStreamingResponse(true);
+      setError(null);
+
+      const response = await sendChatMessage({
+        history: historyBeforeMessage,
+        userMessage: userMessageParts,
+        systemInstruction: chatSettings.systemInstruction,
+        vectorStoreSettings: chatSettings.vectorStore,
+      });
+
+      setChatHistory(prev => {
+        if (prev.length === 0) return prev;
+        const updatedHistory = [...prev];
+        const lastIndex = updatedHistory.length - 1;
+        const lastMessage = updatedHistory[lastIndex];
+        if (lastMessage && lastMessage.role === 'model') {
+          const thinkingSegments = response.thinking.length > 0 ? [...response.thinking] : undefined;
+          const finalText = response.text;
+          const firstPart = lastMessage.parts[0];
+
+          if (firstPart && 'text' in firstPart) {
+            firstPart.text = finalText;
+            lastMessage.thinking = thinkingSegments;
+          } else {
+            updatedHistory[lastIndex] = { role: 'model', parts: [{ text: finalText }], thinking: thinkingSegments };
+          }
         }
-
-        setChatHistory(prev => [...prev, { role: 'user', parts: userMessageParts }]);
-        setChatInput('');
-        setChatFiles(null);
-        
-        setChatHistory(prev => [...prev, { role: 'model', parts: [{ text: '' }] }]);
-
-        const stream = await currentChatSession.sendMessageStream({ message: userMessageParts });
-
-        for await (const chunk of stream) {
-            if (chunk.text) {
-                setChatHistory(prev => {
-                    const newHistory = [...prev];
-                    const lastMessage = newHistory[newHistory.length - 1];
-                    if (lastMessage && lastMessage.role === 'model' && lastMessage.parts[0] && 'text' in lastMessage.parts[0]) {
-                        lastMessage.parts[0].text += chunk.text;
-                    }
-                    return newHistory;
-                });
-            }
-        }
+        return updatedHistory;
+      });
     } catch (err) {
-        console.error("Chat error:", err);
-        const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred.';
-        setError({ message: `Chat failed: ${errorMessage}` });
-        setChatHistory(prev => prev.slice(0, prev.length -1));
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        setChatHistory(prev => (prev.length > 0 ? prev.slice(0, prev.length - 1) : prev));
+        return;
+      }
+      console.error('Chat error:', err);
+      const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred.';
+      setError({ message: `Chat failed: ${errorMessage}` });
+      setChatHistory(prev => (prev.length > 0 ? prev.slice(0, prev.length - 1) : prev));
     } finally {
-        setIsStreamingResponse(false);
+      setIsStreamingResponse(false);
     }
-  }, [ai, canSubmit, chatSession, chatHistory, chatSettings, chatInput, chatFiles]);
+  }, [
+    aiProviderSettings,
+    canSubmit,
+    chatFiles,
+    chatHistory,
+    chatInput,
+    chatSettings.systemInstruction,
+    chatSettings.vectorStore,
+  ]);
   
     const handleSavePromptPreset = (name: string, prompt: string) => {
       setSavedPrompts(prev => {
@@ -367,6 +495,30 @@ const App: React.FC = () => {
               setActiveMode(id as Mode);
               handleReset();
             }} />
+          </div>
+
+          <div className="mb-6 bg-secondary/60 border border-border-color rounded-lg px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 text-text-secondary">
+              <div>
+                <span className="text-text-primary font-semibold">Active AI Provider:</span>{' '}
+                <span className="font-medium text-text-primary">{activeProviderLabel}</span>
+              </div>
+              <span className="hidden sm:inline text-text-secondary">•</span>
+              <div>
+                <span>Model: </span>
+                <span className="font-medium text-text-primary">{activeModelName || 'Select a model'}</span>
+              </div>
+            </div>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs sm:text-sm">
+              <span className={`font-medium ${providerStatusTone}`}>{providerStatusText}</span>
+              <button
+                type="button"
+                onClick={() => setIsChatSettingsModalOpen(true)}
+                className="px-4 py-2 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary-hover transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
+              >
+                Manage AI Settings
+              </button>
+            </div>
           </div>
 
           {activeMode === 'chat' ? (
@@ -444,7 +596,7 @@ const App: React.FC = () => {
           </div>}
         </div>
         <footer className="text-center mt-8 text-text-secondary text-xs">
-          <p>&copy; {new Date().getFullYear()} AI Content Suite. Powered by Gemini.</p>
+          <p>&copy; {new Date().getFullYear()} AI Content Suite. Powered by {providerSummaryText}.</p>
         </footer>
       </div>
 
@@ -453,10 +605,14 @@ const App: React.FC = () => {
         isOpen={isChatSettingsModalOpen}
         onClose={() => setIsChatSettingsModalOpen(false)}
         currentSettings={chatSettings}
-        onSave={(newSettings) => {
+        providerSettings={aiProviderSettings}
+        providers={AI_PROVIDERS}
+        onSave={(newSettings, newProviderSettings) => {
           setChatSettings(newSettings);
+          setAiProviderSettings(newProviderSettings);
           setIsChatSettingsModalOpen(false);
         }}
+        onFetchModels={fetchModelsForProvider}
         savedPrompts={savedPrompts}
         onSavePreset={handleSavePromptPreset}
         onDeletePreset={handleDeletePromptPreset}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1AAdFi9Y_nFooagUjpfxZdO
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+2. Run the app:
    `npm run dev`
+3. In the app, open **Manage AI Settings** and add API keys for the providers you plan to use (OpenAI, OpenRouter, xAI, DeepSeek, Anthropic, or Ollama). Keys are stored locally in your browser.

--- a/components/modals/ChatSettingsModal.tsx
+++ b/components/modals/ChatSettingsModal.tsx
@@ -1,7 +1,24 @@
-
-
-import React, { useState, useEffect, MouseEvent } from 'react';
-import type { ChatSettings, SavedPrompt } from '../../types';
+import React, { useState, useEffect, useCallback, useRef, MouseEvent } from 'react';
+import type {
+  ChatSettings,
+  SavedPrompt,
+  AIProviderSettings,
+  AIProviderId,
+  ModelOption,
+  VectorStoreSettings,
+  EmbeddingProviderId,
+} from '../../types';
+import type { ProviderInfo, EmbeddingProviderInfo } from '../../services/providerRegistry';
+import {
+  DEFAULT_PROVIDER_MODELS,
+  DEFAULT_EMBEDDING_MODELS,
+  INITIAL_CHAT_SETTINGS,
+} from '../../constants';
+import {
+  EMBEDDING_PROVIDERS,
+  requiresEmbeddingApiKey,
+  getEmbeddingProviderDefaultEndpoint,
+} from '../../services/providerRegistry';
 import { XCircleIcon } from '../icons/XCircleIcon';
 import { TrashIcon } from '../icons/TrashIcon';
 
@@ -9,25 +26,264 @@ interface ChatSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   currentSettings: ChatSettings;
-  onSave: (newSettings: ChatSettings) => void;
+  providerSettings: AIProviderSettings;
+  providers: ProviderInfo[];
+  onSave: (newSettings: ChatSettings, providerSettings: AIProviderSettings) => void;
+  onFetchModels: (providerId: AIProviderId, apiKey?: string) => Promise<ModelOption[]>;
   savedPrompts: SavedPrompt[];
   onSavePreset: (name: string, prompt: string) => void;
   onDeletePreset: (name: string) => void;
 }
 
-export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({ isOpen, onClose, currentSettings, onSave, savedPrompts, onSavePreset, onDeletePreset }) => {
-  const [editedSettings, setEditedSettings] = useState<ChatSettings>(currentSettings);
+const ensureVectorStoreSettings = (vectorStore?: VectorStoreSettings): VectorStoreSettings => {
+  const defaults = INITIAL_CHAT_SETTINGS.vectorStore!;
+  return {
+    ...defaults,
+    ...(vectorStore ?? {}),
+    embedding: {
+      ...defaults.embedding,
+      ...(vectorStore?.embedding ?? {}),
+    },
+  };
+};
+
+const withDefaults = (settings: ChatSettings): ChatSettings => ({
+  ...settings,
+  vectorStore: ensureVectorStoreSettings(settings.vectorStore),
+});
+
+export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
+  isOpen,
+  onClose,
+  currentSettings,
+  providerSettings,
+  providers,
+  onSave,
+  onFetchModels,
+  savedPrompts,
+  onSavePreset,
+  onDeletePreset,
+}) => {
+  const [editedSettings, setEditedSettings] = useState<ChatSettings>(() => withDefaults(currentSettings));
+  const [editedProviderSettings, setEditedProviderSettings] = useState<AIProviderSettings>(providerSettings);
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsError, setModelsError] = useState<string | null>(null);
   const [selectedPreset, setSelectedPreset] = useState<string>(''); // Holds the name of the selected preset
+  const loadRequestIdRef = useRef(0);
+
+  const updateVectorStore = useCallback((updater: (prev: VectorStoreSettings) => VectorStoreSettings) => {
+    setEditedSettings(prev => {
+      const currentVector = ensureVectorStoreSettings(prev.vectorStore);
+      return {
+        ...prev,
+        vectorStore: updater(currentVector),
+      };
+    });
+  }, []);
+
+  const loadModels = useCallback(async (providerId: AIProviderId, apiKey?: string) => {
+    const providerInfo = providers.find(p => p.id === providerId);
+    const trimmedKey = apiKey?.trim();
+
+    if (providerInfo?.requiresApiKey && !trimmedKey) {
+      setModelOptions([]);
+      setModelsError(`${providerInfo.label} requires an API key to load models.`);
+      setModelsLoading(false);
+      return;
+    }
+
+    const requestId = ++loadRequestIdRef.current;
+    setModelsLoading(true);
+    setModelsError(null);
+    setModelOptions([]);
+
+    try {
+      const models = await onFetchModels(providerId, trimmedKey);
+      if (loadRequestIdRef.current !== requestId) {
+        return;
+      }
+      setModelOptions(models);
+      if (models.length > 0) {
+        setEditedProviderSettings(prev => {
+          if (prev.selectedProvider !== providerId) return prev;
+          if (models.some(model => model.id === prev.selectedModel)) {
+            return prev;
+          }
+          return { ...prev, selectedModel: models[0].id };
+        });
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      setModelsError(message);
+      setModelOptions([]);
+    } finally {
+      if (loadRequestIdRef.current === requestId) {
+        setModelsLoading(false);
+      }
+    }
+  }, [onFetchModels, providers]);
 
   useEffect(() => {
     if (isOpen) {
-      setEditedSettings(currentSettings);
+      setEditedSettings(withDefaults(currentSettings));
+      setEditedProviderSettings(providerSettings);
+      setModelOptions([]);
+      setModelsError(null);
+      setModelsLoading(false);
       setSelectedPreset(''); // Reset selection when opening
     }
-  }, [isOpen, currentSettings]);
+  }, [isOpen, currentSettings, providerSettings]);
+
+  useEffect(() => {
+    if (isOpen) {
+      const providerId = providerSettings.selectedProvider;
+      const apiKey = providerSettings.apiKeys?.[providerId];
+      loadModels(providerId, apiKey);
+    }
+  }, [isOpen, providerSettings, loadModels]);
 
   const handleSave = () => {
-    onSave(editedSettings);
+    const providerId = editedProviderSettings.selectedProvider;
+    const trimmedModel = editedProviderSettings.selectedModel.trim();
+    const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? DEFAULT_PROVIDER_MODELS[providerSettings.selectedProvider];
+    const sanitizedApiKeys = Object.entries(editedProviderSettings.apiKeys || {}).reduce<AIProviderSettings['apiKeys']>((acc, [key, value]) => {
+      const trimmed = typeof value === 'string' ? value.trim() : value;
+      if (trimmed) {
+        acc[key] = trimmed;
+      }
+      return acc;
+    }, {});
+
+    const draftVectorStore = ensureVectorStoreSettings(editedSettings.vectorStore);
+    const parsedTopK = Number(draftVectorStore.topK);
+    const sanitizedTopK = Number.isFinite(parsedTopK) && parsedTopK > 0 ? Math.min(Math.round(parsedTopK), 20) : 5;
+    const sanitizedVectorStore: VectorStoreSettings = {
+      enabled: Boolean(draftVectorStore.enabled),
+      url: (draftVectorStore.url || '').trim(),
+      apiKey: draftVectorStore.apiKey && draftVectorStore.apiKey.trim() !== '' ? draftVectorStore.apiKey.trim() : undefined,
+      collection: (draftVectorStore.collection || '').trim(),
+      topK: sanitizedTopK,
+      embedding: {
+        provider: draftVectorStore.embedding.provider,
+        model: draftVectorStore.embedding.model.trim(),
+        apiKey:
+          draftVectorStore.embedding.apiKey && draftVectorStore.embedding.apiKey.trim() !== ''
+            ? draftVectorStore.embedding.apiKey.trim()
+            : undefined,
+        baseUrl:
+          draftVectorStore.embedding.baseUrl && draftVectorStore.embedding.baseUrl.trim() !== ''
+            ? draftVectorStore.embedding.baseUrl.trim()
+            : undefined,
+      },
+    };
+
+    const finalProviderSettings: AIProviderSettings = {
+      selectedProvider: providerId,
+      selectedModel: trimmedModel || fallbackModel,
+      apiKeys: sanitizedApiKeys,
+    };
+
+    const finalChatSettings: ChatSettings = {
+      ...editedSettings,
+      vectorStore: sanitizedVectorStore,
+    };
+
+    onSave(finalChatSettings, finalProviderSettings);
+  };
+
+  const handleProviderChange = (providerId: AIProviderId) => {
+    setEditedProviderSettings(prev => {
+      const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? prev.selectedModel;
+      return {
+        ...prev,
+        selectedProvider: providerId,
+        selectedModel: fallbackModel,
+      };
+    });
+    const apiKey = editedProviderSettings.apiKeys?.[providerId];
+    loadModels(providerId, apiKey);
+  };
+
+  const handleApiKeyChange = (providerId: AIProviderId, value: string) => {
+    setEditedProviderSettings(prev => ({
+      ...prev,
+      apiKeys: { ...prev.apiKeys, [providerId]: value },
+    }));
+  };
+
+  const handleModelInputChange = (value: string) => {
+    setEditedProviderSettings(prev => ({
+      ...prev,
+      selectedModel: value,
+    }));
+  };
+
+  const handleVectorStoreEnabledChange = (enabled: boolean) => {
+    updateVectorStore(prev => ({ ...prev, enabled }));
+  };
+
+  const handleVectorStoreUrlChange = (value: string) => {
+    updateVectorStore(prev => ({ ...prev, url: value }));
+  };
+
+  const handleVectorStoreCollectionChange = (value: string) => {
+    updateVectorStore(prev => ({ ...prev, collection: value }));
+  };
+
+  const handleVectorStoreApiKeyChange = (value: string) => {
+    updateVectorStore(prev => ({ ...prev, apiKey: value }));
+  };
+
+  const handleVectorStoreTopKChange = (value: string) => {
+    const numericValue = Number(value);
+    updateVectorStore(prev => ({
+      ...prev,
+      topK: value === '' ? 0 : Number.isFinite(numericValue) ? numericValue : prev.topK,
+    }));
+  };
+
+  const handleEmbeddingProviderChange = (providerId: EmbeddingProviderId) => {
+    updateVectorStore(prev => {
+      if (prev.embedding.provider === providerId) {
+        return { ...prev, embedding: { ...prev.embedding, provider: providerId } };
+      }
+      const defaultModel = DEFAULT_EMBEDDING_MODELS[providerId] ?? '';
+      const defaultEndpoint = getEmbeddingProviderDefaultEndpoint(providerId) ?? '';
+      return {
+        ...prev,
+        embedding: {
+          ...prev.embedding,
+          provider: providerId,
+          model: defaultModel,
+          baseUrl: providerId === 'custom' ? '' : defaultEndpoint,
+        },
+      };
+    });
+  };
+
+  const handleEmbeddingModelChange = (value: string) => {
+    updateVectorStore(prev => ({
+      ...prev,
+      embedding: { ...prev.embedding, model: value },
+    }));
+  };
+
+  const handleEmbeddingApiKeyChange = (value: string) => {
+    updateVectorStore(prev => ({
+      ...prev,
+      embedding: { ...prev.embedding, apiKey: value },
+    }));
+  };
+
+  const handleEmbeddingBaseUrlChange = (value: string) => {
+    updateVectorStore(prev => ({
+      ...prev,
+      embedding: { ...prev.embedding, baseUrl: value },
+    }));
   };
 
   const handleLoadPreset = (name: string) => {
@@ -61,6 +317,19 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({ isOpen, on
     }
   };
 
+  const selectedProviderInfo = providers.find(p => p.id === editedProviderSettings.selectedProvider);
+  const selectedApiKey = editedProviderSettings.apiKeys?.[editedProviderSettings.selectedProvider] ?? '';
+  const vectorStoreSettings = editedSettings.vectorStore ?? ensureVectorStoreSettings();
+  const embeddingSettings = vectorStoreSettings.embedding;
+  const selectedEmbeddingProviderInfo = EMBEDDING_PROVIDERS.find(p => p.id === embeddingSettings.provider) as
+    | EmbeddingProviderInfo
+    | undefined;
+  const embeddingEndpointPlaceholder =
+    embeddingSettings.provider === 'custom'
+      ? 'https://your-embedding-endpoint/v1/embeddings'
+      : getEmbeddingProviderDefaultEndpoint(embeddingSettings.provider) ?? '';
+  const embeddingRequiresApiKey = requiresEmbeddingApiKey(embeddingSettings.provider);
+
   if (!isOpen) return null;
 
   return (
@@ -81,11 +350,266 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({ isOpen, on
         
         <div className="p-6 sm:p-8 space-y-4">
             <div>
+              <label htmlFor="provider-selector" className="block text-sm font-medium text-text-secondary mb-2">
+                AI Provider
+              </label>
+              <select
+                id="provider-selector"
+                value={editedProviderSettings.selectedProvider}
+                onChange={(e) => handleProviderChange(e.target.value as AIProviderId)}
+                className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
+              >
+                {providers.map(provider => (
+                  <option key={provider.id} value={provider.id}>{provider.label}</option>
+                ))}
+              </select>
+              {selectedProviderInfo?.docsUrl && (
+                <p className="mt-1 text-xs text-text-secondary">
+                  API docs:{' '}
+                  <a href={selectedProviderInfo.docsUrl} target="_blank" rel="noreferrer" className="text-primary underline">
+                    {selectedProviderInfo.docsUrl}
+                  </a>
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="provider-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                API Key
+              </label>
+              <input
+                id="provider-api-key"
+                type="password"
+                value={selectedApiKey}
+                onChange={(e) => handleApiKeyChange(editedProviderSettings.selectedProvider, e.target.value)}
+                placeholder={selectedProviderInfo?.requiresApiKey ? 'Enter your API key' : 'Optional for this provider'}
+                className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+              />
+              <p className="mt-1 text-xs text-text-secondary">
+                {selectedProviderInfo?.requiresApiKey
+                  ? 'Required to authenticate requests.'
+                  : 'Optional. Leave blank for local deployments.'}
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="provider-model" className="block text-sm font-medium text-text-secondary mb-2">
+                Model
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="provider-model"
+                  type="text"
+                  list="provider-model-options"
+                  value={editedProviderSettings.selectedModel}
+                  onChange={(e) => handleModelInputChange(e.target.value)}
+                  placeholder="Select or enter a model name"
+                  className="flex-grow px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => loadModels(editedProviderSettings.selectedProvider, selectedApiKey)}
+                  className="px-3 py-2 bg-muted text-text-primary font-medium rounded-md hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary disabled:opacity-50"
+                  disabled={modelsLoading}
+                >
+                  {modelsLoading ? 'Loading...' : 'Refresh'}
+                </button>
+              </div>
+              <datalist id="provider-model-options">
+                {modelOptions.map(model => (
+                  <option key={model.id} value={model.id}>{model.label}</option>
+                ))}
+              </datalist>
+              {modelsError ? (
+                <p className="mt-1 text-xs text-destructive">{modelsError}</p>
+              ) : modelOptions.length > 0 ? (
+                <p className="mt-1 text-xs text-text-secondary">Choose a model from the suggestions or provide a custom value.</p>
+              ) : (
+                <p className="mt-1 text-xs text-text-secondary">Enter a model name or refresh to fetch available options.</p>
+              )}
+            </div>
+
+            <div className="border border-border-color rounded-lg p-4 space-y-4">
+              <div className="flex items-start gap-3">
+                <input
+                  id="vector-store-enabled"
+                  type="checkbox"
+                  checked={vectorStoreSettings.enabled}
+                  onChange={(e) => handleVectorStoreEnabledChange(e.target.checked)}
+                  className="mt-1 h-4 w-4 text-primary focus:ring-ring border-border-color rounded"
+                />
+                <div>
+                  <label htmlFor="vector-store-enabled" className="text-sm font-medium text-text-secondary">
+                    Enable Qdrant retrieval
+                  </label>
+                  <p className="mt-1 text-xs text-text-secondary">
+                    When enabled, chat requests will fetch relevant knowledge base entries from your centralized Qdrant
+                    collection and share them with the model before it responds.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="sm:col-span-2">
+                  <label htmlFor="vector-store-url" className="block text-sm font-medium text-text-secondary mb-2">
+                    Qdrant URL
+                  </label>
+                  <input
+                    id="vector-store-url"
+                    type="url"
+                    value={vectorStoreSettings.url}
+                    onChange={(e) => handleVectorStoreUrlChange(e.target.value)}
+                    placeholder="https://qdrant.yourcompany.com"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="vector-store-collection" className="block text-sm font-medium text-text-secondary mb-2">
+                    Collection name
+                  </label>
+                  <input
+                    id="vector-store-collection"
+                    type="text"
+                    value={vectorStoreSettings.collection}
+                    onChange={(e) => handleVectorStoreCollectionChange(e.target.value)}
+                    placeholder="knowledge-base"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="vector-store-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                    Qdrant API key
+                  </label>
+                  <input
+                    id="vector-store-api-key"
+                    type="password"
+                    value={vectorStoreSettings.apiKey ?? ''}
+                    onChange={(e) => handleVectorStoreApiKeyChange(e.target.value)}
+                    placeholder="Optional"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                  <p className="mt-1 text-xs text-text-secondary">
+                    Leave blank if your cluster is secured by network rules. Provide a key for hosted deployments.
+                  </p>
+                </div>
+
+                <div>
+                  <label htmlFor="vector-store-topk" className="block text-sm font-medium text-text-secondary mb-2">
+                    Results per query (Top-k)
+                  </label>
+                  <input
+                    id="vector-store-topk"
+                    type="number"
+                    min={1}
+                    max={20}
+                    value={vectorStoreSettings.topK || ''}
+                    onChange={(e) => handleVectorStoreTopKChange(e.target.value)}
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label htmlFor="embedding-provider" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding provider
+                  </label>
+                  <select
+                    id="embedding-provider"
+                    value={embeddingSettings.provider}
+                    onChange={(e) => handleEmbeddingProviderChange(e.target.value as EmbeddingProviderId)}
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  >
+                    {EMBEDDING_PROVIDERS.map(provider => (
+                      <option key={provider.id} value={provider.id}>
+                        {provider.label}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedEmbeddingProviderInfo?.docsUrl && (
+                    <p className="mt-1 text-xs text-text-secondary">
+                      API docs:{' '}
+                      <a
+                        href={selectedEmbeddingProviderInfo.docsUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary underline"
+                      >
+                        {selectedEmbeddingProviderInfo.docsUrl}
+                      </a>
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="embedding-model" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding model
+                  </label>
+                  <input
+                    id="embedding-model"
+                    type="text"
+                    value={embeddingSettings.model}
+                    onChange={(e) => handleEmbeddingModelChange(e.target.value)}
+                    placeholder="text-embedding-3-small"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="embedding-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding API key
+                  </label>
+                  <input
+                    id="embedding-api-key"
+                    type="password"
+                    value={embeddingSettings.apiKey ?? ''}
+                    onChange={(e) => handleEmbeddingApiKeyChange(e.target.value)}
+                    placeholder={embeddingRequiresApiKey ? 'Required for this provider' : 'Optional'}
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                  <p className="mt-1 text-xs text-text-secondary">
+                    {embeddingRequiresApiKey
+                      ? 'Required to request embeddings from this provider.'
+                      : 'Optional. Local endpoints such as Ollama typically do not need an API key.'}
+                  </p>
+                </div>
+
+                <div>
+                  <label htmlFor="embedding-endpoint" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding endpoint override
+                  </label>
+                  <input
+                    id="embedding-endpoint"
+                    type="url"
+                    value={embeddingSettings.baseUrl ?? ''}
+                    onChange={(e) => handleEmbeddingBaseUrlChange(e.target.value)}
+                    placeholder={embeddingEndpointPlaceholder || 'https://...' }
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                  <p className="mt-1 text-xs text-text-secondary">
+                    Leave blank to use the default endpoint for {selectedEmbeddingProviderInfo?.label ?? 'this provider'}.
+                    Provide a custom URL for self-hosted or proxy deployments.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div>
               <label htmlFor="preset-selector" className="block text-sm font-medium text-text-secondary mb-2">
                 Manage Presets
               </label>
               <div className="flex items-center gap-2">
-                <select 
+                <select
                   id="preset-selector"
                   value={selectedPreset}
                   onChange={(e) => handleLoadPreset(e.target.value)}

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,17 @@
 
 
-import type { ProgressUpdate, ReasoningSettings, ScaffolderSettings, RequestSplitterSettings, PromptEnhancerSettings, AgentDesignerSettings, ChatSettings } from './types';
+import type {
+  ProgressUpdate,
+  ReasoningSettings,
+  ScaffolderSettings,
+  RequestSplitterSettings,
+  PromptEnhancerSettings,
+  AgentDesignerSettings,
+  ChatSettings,
+  AIProviderSettings,
+  AIProviderId,
+  EmbeddingProviderId,
+} from './types';
 
 // Import all summary prompts from the new modular structure
 import * as summaryPrompts from './prompts/summaries';
@@ -19,9 +30,22 @@ import { REQUEST_SPLITTER_PLANNING_PROMPT_TEMPLATE, REQUEST_SPLITTER_GENERATION_
 import { PROMPT_ENHANCER_PROMPT_TEMPLATE } from './prompts/promptEnhancer/index';
 // FIX: Corrected import path for agent designer template
 import { AGENT_DESIGNER_PROMPT_TEMPLATE } from './prompts/agentDesigner/index';
+export const DEFAULT_PROVIDER_MODELS: Record<AIProviderId, string> = {
+  openai: 'gpt-4o-mini',
+  openrouter: 'openrouter/auto',
+  xai: 'grok-beta',
+  deepseek: 'deepseek-chat',
+  anthropic: 'claude-3-5-sonnet-latest',
+  ollama: 'llama3.1:8b',
+};
 
-
-export const GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
+export const DEFAULT_EMBEDDING_MODELS: Record<EmbeddingProviderId, string> = {
+  openai: 'text-embedding-3-small',
+  openrouter: 'text-embedding-3-small',
+  deepseek: 'deepseek-embedding',
+  ollama: 'nomic-embed-text',
+  custom: '',
+};
 
 // Approximate token estimation: 1 token ~ 4 characters.
 // Target chunk size for LLM processing. Drastically increased to maximize model's context window.
@@ -103,6 +127,25 @@ export const INITIAL_AGENT_DESIGNER_SETTINGS: AgentDesignerSettings = {
 
 export const INITIAL_CHAT_SETTINGS: ChatSettings = {
     systemInstruction: 'You are a helpful and friendly AI assistant. Answer the user\'s questions clearly and concisely.',
+    vectorStore: {
+        enabled: false,
+        url: '',
+        apiKey: '',
+        collection: '',
+        topK: 5,
+        embedding: {
+            provider: 'openai',
+            model: DEFAULT_EMBEDDING_MODELS.openai,
+            apiKey: '',
+            baseUrl: '',
+        },
+    },
+};
+
+export const INITIAL_AI_PROVIDER_SETTINGS: AIProviderSettings = {
+    selectedProvider: 'openai',
+    selectedModel: DEFAULT_PROVIDER_MODELS.openai,
+    apiKeys: {},
 };
 
 // --- Prompt Collections (Re-constructed from imports) ---

--- a/index.html
+++ b/index.html
@@ -182,7 +182,6 @@
     "react": "https://esm.sh/react@^19.1.0",
     "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
     "react/": "https://esm.sh/react@^19.1.0/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.3.0",
     "pdfjs-dist": "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.4.168/build/pdf.min.mjs",
     "tesseract.js": "https://esm.sh/tesseract.js@5.1.0"
   }

--- a/index.tsx
+++ b/index.tsx
@@ -28,11 +28,11 @@ if (typeof process === 'undefined') {
   window.process = { env: {} };
 }
 if (!process.env.API_KEY) {
-  // IMPORTANT: Replace this with your actual API key or use environment variables.
+  // IMPORTANT: Replace this with your default API key or manage credentials at runtime via the AI Settings dialog.
   // For safety, it's best to manage API keys outside of version control.
   // This is only a placeholder for the application to run in a sandboxed environment.
-  // process.env.API_KEY = "YOUR_GEMINI_API_KEY"; 
-  console.warn("API_KEY environment variable is not set. Gemini API calls will fail.");
+  // process.env.API_KEY = "YOUR_DEFAULT_AI_API_KEY";
+  console.warn("API_KEY environment variable is not set. Configure provider keys from the AI Settings dialog before using AI features.");
 }
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "AI Content Suite",
-  "description": "An AI-powered text analysis and content generation tool. It can summarize technical transcripts, extract writing styles, rewrite documents, decompose large requests, enhance prompts for agents, and more using the Gemini API.",
+  "description": "An AI-powered text analysis and content generation tool. It can summarize technical transcripts, extract writing styles, rewrite documents, decompose large requests, enhance prompts for agents, and more using configurable AI providers (OpenAI, OpenRouter, xAI, DeepSeek, Anthropic, and Ollama).",
   "requestFramePermissions": [],
   "prompt": ""
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@google/genai": "^1.3.0",
     "pdfjs-dist": "4.4.168",
     "tesseract.js": "5.1.0"
   },

--- a/services/providerClient.ts
+++ b/services/providerClient.ts
@@ -1,0 +1,483 @@
+import type { AIProviderId, ThinkingSegment } from '../types';
+import { DEFAULT_PROVIDER_MODELS } from '../constants';
+import { getProviderLabel, requiresApiKey, ANTHROPIC_API_VERSION } from './providerRegistry';
+
+export type ResponseFormat = 'text' | 'json';
+
+export type ProviderMessages = Array<{
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}>;
+
+export type ProviderCallArgs = {
+  messages: ProviderMessages;
+  maxOutputTokens?: number;
+  responseFormat?: ResponseFormat;
+  signal?: AbortSignal;
+};
+
+interface ActiveProviderConfig {
+  providerId: AIProviderId;
+  model: string;
+  apiKey?: string;
+}
+
+export interface ProviderTextResponse {
+  text: string;
+  thinking: ThinkingSegment[];
+}
+
+let activeConfig: ActiveProviderConfig = {
+  providerId: 'openai',
+  model: DEFAULT_PROVIDER_MODELS.openai,
+  apiKey: undefined,
+};
+
+const ensureConfig = (): ActiveProviderConfig => {
+  if (!activeConfig.model || activeConfig.model.trim() === '') {
+    const fallbackModel = DEFAULT_PROVIDER_MODELS[activeConfig.providerId];
+    if (!fallbackModel) {
+      throw new Error('No model configured for the selected provider. Please choose a model in settings.');
+    }
+    activeConfig = { ...activeConfig, model: fallbackModel };
+  }
+  return activeConfig;
+};
+
+export const setActiveProviderConfig = (config: { providerId: AIProviderId; model?: string; apiKey?: string }) => {
+  activeConfig = {
+    providerId: config.providerId,
+    model: config.model && config.model.trim() !== '' ? config.model.trim() : DEFAULT_PROVIDER_MODELS[config.providerId],
+    apiKey: config.apiKey && config.apiKey.trim() !== '' ? config.apiKey.trim() : undefined,
+  };
+};
+
+export const getActiveProviderConfig = (): ActiveProviderConfig => ({ ...activeConfig });
+
+export const getActiveProviderLabel = (): string => getProviderLabel(activeConfig.providerId);
+
+export const getActiveModelName = (): string => ensureConfig().model;
+
+const toOpenAIMessage = (messages: ProviderMessages) =>
+  messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+
+const THINKING_HINT_KEYWORDS = ['reason', 'think', 'analysis', 'chain', 'deliberat', 'scratchpad', 'plan', 'inner', 'cot', 'reflect'];
+const THINKING_LABEL_ALIASES: Record<string, string> = {
+  cot: 'Chain of Thought',
+  'chain_of_thought': 'Chain of Thought',
+  'chain-of-thought': 'Chain of Thought',
+  reasoning: 'Reasoning',
+  reason: 'Reasoning',
+  analysis: 'Analysis',
+  deliberate: 'Deliberation',
+  deliberation: 'Deliberation',
+  reflection: 'Reflection',
+  scratchpad: 'Scratchpad',
+  plan: 'Plan',
+  'inner_monologue': 'Inner Monologue',
+  'inner-monologue': 'Inner Monologue',
+};
+
+type NormalizedCollector = {
+  textParts: string[];
+  thinkingSegments: ThinkingSegment[];
+};
+
+const createCollector = (): NormalizedCollector => ({ textParts: [], thinkingSegments: [] });
+
+const isThinkingHint = (value?: string): boolean => {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return THINKING_HINT_KEYWORDS.some((keyword) => normalized.includes(keyword));
+};
+
+const formatThinkingLabel = (hint?: string): string => {
+  if (!hint) return 'Thinking';
+  const normalizedKey = hint.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  if (THINKING_LABEL_ALIASES[normalizedKey]) {
+    return THINKING_LABEL_ALIASES[normalizedKey];
+  }
+  const cleaned = hint.replace(/[^a-zA-Z0-9_\s-]+/g, ' ').trim();
+  if (!cleaned) {
+    return 'Thinking';
+  }
+  return cleaned
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+const pushText = (collector: NormalizedCollector, value: unknown) => {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  collector.textParts.push(trimmed);
+};
+
+const pushThinking = (collector: NormalizedCollector, value: unknown, hint?: string) => {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  const normalizedHint = hint?.toLowerCase();
+  collector.thinkingSegments.push({
+    type: normalizedHint,
+    label: formatThinkingLabel(normalizedHint ?? hint),
+    text: trimmed,
+  });
+};
+
+const SKIP_OBJECT_KEYS = new Set([
+  'id',
+  'index',
+  'finish_reason',
+  'logprobs',
+  'usage',
+  'role',
+  'model',
+  'object',
+  'created',
+  'prompt_filter_results',
+]);
+
+const collectNormalizedParts = (value: unknown, collector: NormalizedCollector, hint?: string) => {
+  if (value == null) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    if (isThinkingHint(hint)) {
+      pushThinking(collector, value, hint);
+    } else {
+      pushText(collector, value);
+    }
+    return;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    if (!isThinkingHint(hint)) {
+      pushText(collector, String(value));
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectNormalizedParts(item, collector, hint));
+    return;
+  }
+
+  if (typeof value === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    const typeHint = typeof objectValue.type === 'string' ? (objectValue.type as string) : hint;
+
+    if (typeof objectValue.text === 'string') {
+      if (isThinkingHint(typeHint)) {
+        pushThinking(collector, objectValue.text, typeHint);
+      } else {
+        pushText(collector, objectValue.text);
+      }
+    }
+
+    if (typeof objectValue.output_text === 'string') {
+      if (isThinkingHint(typeHint)) {
+        pushThinking(collector, objectValue.output_text, typeHint);
+      } else {
+        pushText(collector, objectValue.output_text);
+      }
+    }
+
+    if (typeof objectValue.message === 'string') {
+      if (isThinkingHint(typeHint)) {
+        pushThinking(collector, objectValue.message, typeHint);
+      } else {
+        pushText(collector, objectValue.message);
+      }
+    }
+
+    Object.entries(objectValue).forEach(([key, nestedValue]) => {
+      if (key === 'type' || key === 'text' || key === 'output_text' || key === 'message') {
+        return;
+      }
+      if (SKIP_OBJECT_KEYS.has(key)) {
+        return;
+      }
+      const nextHint = isThinkingHint(key) ? key : typeHint;
+      collectNormalizedParts(nestedValue, collector, nextHint);
+    });
+  }
+};
+
+const dedupeThinkingSegments = (segments: ThinkingSegment[]): ThinkingSegment[] => {
+  const seen = new Set<string>();
+  return segments
+    .map((segment) => ({ ...segment, text: segment.text.trim() }))
+    .filter((segment) => {
+      if (!segment.text) return false;
+      const key = `${segment.type ?? 'thinking'}::${segment.text}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+};
+
+const finalizeCollector = (collector: NormalizedCollector, fallback?: string): ProviderTextResponse => {
+  const textParts = collector.textParts.map((part) => part.trim()).filter(Boolean);
+  let text = textParts.join('\n\n');
+  if (!text && fallback && fallback.trim()) {
+    text = fallback.trim();
+  }
+  return {
+    text,
+    thinking: dedupeThinkingSegments(collector.thinkingSegments),
+  };
+};
+
+const extractFirstNonEmpty = (candidates: unknown[]): string | undefined => {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    } else if (Array.isArray(candidate)) {
+      const joined = candidate
+        .map((item) => {
+          if (typeof item === 'string') return item;
+          if (item && typeof item === 'object' && typeof (item as any).text === 'string') {
+            return (item as any).text;
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .join('\n\n')
+        .trim();
+      if (joined) {
+        return joined;
+      }
+    } else if (candidate && typeof candidate === 'object' && typeof (candidate as any).text === 'string') {
+      const trimmed = ((candidate as any).text as string).trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+};
+
+const callOpenAICompatible = async (
+  endpoint: string,
+  apiKey: string,
+  { messages, maxOutputTokens, responseFormat, signal }: ProviderCallArgs,
+  extraHeaders: Record<string, string> = {},
+): Promise<ProviderTextResponse> => {
+  const requestBody: Record<string, unknown> = {
+    model: ensureConfig().model,
+    messages: toOpenAIMessage(messages),
+    temperature: 0.7,
+    stream: false,
+  };
+
+  if (typeof maxOutputTokens === 'number') {
+    requestBody.max_tokens = maxOutputTokens;
+  }
+  if (responseFormat === 'json') {
+    requestBody.response_format = { type: 'json_object' };
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+    ...extraHeaders,
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(requestBody),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Provider request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const choice = data?.choices?.[0];
+  const message = choice?.message ?? {};
+
+  const collector = createCollector();
+  collectNormalizedParts(message?.content, collector);
+  collectNormalizedParts(message?.reasoning, collector, 'reasoning');
+  collectNormalizedParts(message?.thinking, collector, 'thinking');
+  collectNormalizedParts(choice?.reasoning, collector, 'reasoning');
+  collectNormalizedParts(choice?.thinking, collector, 'thinking');
+
+  const fallback = extractFirstNonEmpty([
+    message?.content,
+    message?.text,
+    choice?.text,
+  ]);
+
+  return finalizeCollector(collector, fallback);
+};
+
+const callAnthropic = async (
+  { messages, maxOutputTokens, responseFormat, signal }: ProviderCallArgs,
+  apiKey: string,
+): Promise<ProviderTextResponse> => {
+  const systemMessage = messages.find((msg) => msg.role === 'system');
+  const conversation = messages.filter((msg) => msg.role !== 'system').map((msg) => ({
+    role: msg.role === 'assistant' ? 'assistant' : 'user',
+    content: [{ type: 'text', text: msg.content }],
+  }));
+
+  const body: Record<string, unknown> = {
+    model: ensureConfig().model,
+    max_tokens: maxOutputTokens ?? 4096,
+    temperature: 0.7,
+    messages: conversation,
+  };
+
+  if (systemMessage) {
+    body.system = systemMessage.content;
+  }
+  if (responseFormat === 'json') {
+    body.response_format = { type: 'json_object' };
+  }
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_API_VERSION,
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Anthropic request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const collector = createCollector();
+  collectNormalizedParts(data?.content, collector);
+  collectNormalizedParts((data as any)?.reasoning, collector, 'reasoning');
+
+  const fallback = extractFirstNonEmpty([data?.content]);
+  const result = finalizeCollector(collector, fallback);
+  if (!result.text && result.thinking.length === 0) {
+    throw new Error('Anthropic did not return a textual response.');
+  }
+  return result;
+};
+
+const callOllama = async ({ messages, maxOutputTokens, signal }: ProviderCallArgs): Promise<ProviderTextResponse> => {
+  const systemMessages = messages.filter((msg) => msg.role === 'system');
+  const conversation = messages.filter((msg) => msg.role !== 'system');
+
+  const promptSections: string[] = [];
+  if (systemMessages.length > 0) {
+    promptSections.push(`System:\n${systemMessages.map((msg) => msg.content).join('\n\n')}`);
+  }
+
+  conversation.forEach((msg) => {
+    const speaker = msg.role === 'assistant' ? 'Assistant' : 'User';
+    promptSections.push(`${speaker}: ${msg.content}`);
+  });
+  promptSections.push('Assistant:');
+
+  const body: Record<string, unknown> = {
+    model: ensureConfig().model,
+    prompt: promptSections.join('\n\n'),
+    stream: false,
+  };
+
+  if (typeof maxOutputTokens === 'number') {
+    body.options = { num_predict: maxOutputTokens };
+  }
+
+  const response = await fetch('http://127.0.0.1:11434/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Ollama request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!data || typeof data.response !== 'string') {
+    throw new Error('Ollama did not return a textual response.');
+  }
+  return { text: data.response, thinking: [] };
+};
+
+export const callProvider = async ({ messages, maxOutputTokens, responseFormat = 'text', signal }: ProviderCallArgs): Promise<ProviderTextResponse> => {
+  if (signal?.aborted) {
+    throw new DOMException('Aborted by user', 'AbortError');
+  }
+
+  const config = ensureConfig();
+  const providerLabel = getProviderLabel(config.providerId);
+  const apiKey = config.apiKey;
+
+  if (requiresApiKey(config.providerId) && !apiKey) {
+    throw new Error(`${providerLabel} requires an API key. Please add it in settings before running this action.`);
+  }
+
+  try {
+    switch (config.providerId) {
+      case 'openai':
+        return await callOpenAICompatible('https://api.openai.com/v1/chat/completions', apiKey!, {
+          messages,
+          maxOutputTokens,
+          responseFormat,
+          signal,
+        });
+      case 'openrouter': {
+        const referer = typeof window !== 'undefined' ? window.location.origin : 'https://local.app';
+        return await callOpenAICompatible(
+          'https://openrouter.ai/api/v1/chat/completions',
+          apiKey!,
+          { messages, maxOutputTokens, responseFormat, signal },
+          { 'HTTP-Referer': referer, 'X-Title': 'AI Content Suite' },
+        );
+      }
+      case 'xai':
+        return await callOpenAICompatible('https://api.x.ai/v1/chat/completions', apiKey!, {
+          messages,
+          maxOutputTokens,
+          responseFormat,
+          signal,
+        });
+      case 'deepseek':
+        return await callOpenAICompatible('https://api.deepseek.com/chat/completions', apiKey!, {
+          messages,
+          maxOutputTokens,
+          responseFormat,
+          signal,
+        });
+      case 'anthropic':
+        return await callAnthropic({ messages, maxOutputTokens, responseFormat, signal }, apiKey!);
+      case 'ollama':
+        return await callOllama({ messages, maxOutputTokens, responseFormat, signal });
+      default:
+        throw new Error(`Unsupported provider: ${config.providerId}`);
+    }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
+    throw new Error(`${providerLabel} request failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+};

--- a/services/providerRegistry.ts
+++ b/services/providerRegistry.ts
@@ -1,0 +1,171 @@
+import type { AIProviderId, EmbeddingProviderId, ModelOption } from '../types';
+
+export interface ProviderInfo {
+  id: AIProviderId;
+  label: string;
+  requiresApiKey: boolean;
+  docsUrl?: string;
+}
+
+export interface EmbeddingProviderInfo {
+  id: EmbeddingProviderId;
+  label: string;
+  requiresApiKey: boolean;
+  docsUrl?: string;
+  defaultEndpoint?: string;
+}
+
+export const ANTHROPIC_API_VERSION = '2023-06-01';
+
+export const AI_PROVIDERS: ProviderInfo[] = [
+  { id: 'openai', label: 'OpenAI', requiresApiKey: true, docsUrl: 'https://platform.openai.com/' },
+  { id: 'openrouter', label: 'OpenRouter', requiresApiKey: true, docsUrl: 'https://openrouter.ai/' },
+  { id: 'xai', label: 'xAI (Grok)', requiresApiKey: true, docsUrl: 'https://docs.x.ai/' },
+  { id: 'deepseek', label: 'DeepSeek', requiresApiKey: true, docsUrl: 'https://platform.deepseek.com/' },
+  { id: 'anthropic', label: 'Anthropic', requiresApiKey: true, docsUrl: 'https://docs.anthropic.com/' },
+  { id: 'ollama', label: 'Ollama (Local)', requiresApiKey: false, docsUrl: 'https://ollama.com/' },
+];
+
+const PROVIDER_LABEL_MAP: Record<AIProviderId, ProviderInfo> = AI_PROVIDERS.reduce((acc, provider) => {
+  acc[provider.id] = provider;
+  return acc;
+}, {} as Record<AIProviderId, ProviderInfo>);
+
+export const EMBEDDING_PROVIDERS: EmbeddingProviderInfo[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.openai.com/docs/guides/embeddings',
+    defaultEndpoint: 'https://api.openai.com/v1/embeddings',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    requiresApiKey: true,
+    docsUrl: 'https://openrouter.ai/docs#embeddings',
+    defaultEndpoint: 'https://openrouter.ai/api/v1/embeddings',
+  },
+  {
+    id: 'deepseek',
+    label: 'DeepSeek',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.deepseek.com/docs/api/embeddings',
+    defaultEndpoint: 'https://api.deepseek.com/v1/embeddings',
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (Local)',
+    requiresApiKey: false,
+    docsUrl: 'https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings',
+    defaultEndpoint: 'http://127.0.0.1:11434/api/embeddings',
+  },
+  {
+    id: 'custom',
+    label: 'Custom (OpenAI-compatible)',
+    requiresApiKey: false,
+  },
+];
+
+const EMBEDDING_PROVIDER_MAP: Record<EmbeddingProviderId, EmbeddingProviderInfo> = EMBEDDING_PROVIDERS.reduce((acc, provider) => {
+  acc[provider.id] = provider;
+  return acc;
+}, {} as Record<EmbeddingProviderId, EmbeddingProviderInfo>);
+
+export const requiresApiKey = (providerId: AIProviderId): boolean => PROVIDER_LABEL_MAP[providerId]?.requiresApiKey ?? true;
+
+export const getProviderLabel = (providerId: AIProviderId): string => PROVIDER_LABEL_MAP[providerId]?.label ?? providerId;
+
+export const requiresEmbeddingApiKey = (providerId: EmbeddingProviderId): boolean =>
+  EMBEDDING_PROVIDER_MAP[providerId]?.requiresApiKey ?? true;
+
+export const getEmbeddingProviderLabel = (providerId: EmbeddingProviderId): string =>
+  EMBEDDING_PROVIDER_MAP[providerId]?.label ?? providerId;
+
+export const getEmbeddingProviderDefaultEndpoint = (providerId: EmbeddingProviderId): string | undefined =>
+  EMBEDDING_PROVIDER_MAP[providerId]?.defaultEndpoint;
+
+export const fetchModelsForProvider = async (
+  providerId: AIProviderId,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<ModelOption[]> => {
+  switch (providerId) {
+    case 'openai': {
+      if (!apiKey) throw new Error('An OpenAI API key is required to load models.');
+      const response = await fetch('https://api.openai.com/v1/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`OpenAI model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.id }));
+    }
+    case 'openrouter': {
+      const response = await fetch('https://openrouter.ai/api/v1/models', { signal });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`OpenRouter model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.name || model.id }));
+    }
+    case 'xai': {
+      if (!apiKey) throw new Error('An xAI API key is required to load models.');
+      const response = await fetch('https://api.x.ai/v1/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`xAI model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      const models = Array.isArray(data?.data) ? data.data : data?.models;
+      return (models || []).map((model: any) => ({ id: model.id ?? model.name, label: model.id ?? model.name }));
+    }
+    case 'deepseek': {
+      if (!apiKey) throw new Error('A DeepSeek API key is required to load models.');
+      const response = await fetch('https://api.deepseek.com/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`DeepSeek model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.id }));
+    }
+    case 'anthropic': {
+      if (!apiKey) throw new Error('An Anthropic API key is required to load models.');
+      const response = await fetch('https://api.anthropic.com/v1/models', {
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': ANTHROPIC_API_VERSION,
+        },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`Anthropic model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.display_name || model.id }));
+    }
+    case 'ollama': {
+      const response = await fetch('http://127.0.0.1:11434/api/tags', { signal });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`Ollama model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.models || []).map((model: any) => ({ id: model?.name ?? model?.model, label: model?.name ?? model?.model }));
+    }
+    default:
+      return [];
+  }
+};

--- a/services/reasoningService.ts
+++ b/services/reasoningService.ts
@@ -1,7 +1,7 @@
 
 
 import type { ProgressUpdate, ReasoningOutput, ReasoningSettings, ReasoningNode, ReasoningNodeType, ReasoningTree } from '../types';
-import { generateText } from './geminiService';
+import { generateText, getActiveModelName } from './geminiService';
 // FIX: Corrected import path for reasoning prompts
 import * as Prompts from '../prompts/reasoning/index';
 import { processTranscript } from './summarizationService';
@@ -186,7 +186,7 @@ export const processReasoningRequest = async (
             exported_at: new Date().toISOString(),
         },
         audit: {
-            model: 'gemini-2.5-flash',
+            model: getActiveModelName(),
             tokens_in: 0,
             tokens_out: 0,
             cost_usd: 0.0,

--- a/services/reportGenerator.ts
+++ b/services/reportGenerator.ts
@@ -1,6 +1,7 @@
 
 
 import type { ProcessedOutput, Mode, SummaryOutput, StyleModelOutput, RewriterOutput, MathFormatterOutput } from '../types';
+import { getActiveModelName, getActiveProviderLabel } from './geminiService';
 
 declare var marked: any;
 declare var hljs: any;
@@ -29,6 +30,14 @@ const formatDate = (date: Date) => {
   });
 };
 
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 const generateHtmlReport = (output: ProcessedOutput, mode: Mode, styleTarget?: string, suggestions?: string[] | null): string => {
   const generationDate = formatDate(new Date());
   const isTechnical = mode === 'technical' && 'finalSummary' in output;
@@ -40,6 +49,11 @@ const generateHtmlReport = (output: ProcessedOutput, mode: Mode, styleTarget?: s
   const styleOutput = isStyle ? output as StyleModelOutput : null;
   const rewriterOutput = isRewriter ? output as RewriterOutput : null;
   const formatterOutput = isFormatter ? output as MathFormatterOutput : null;
+
+  const providerLabel = getActiveProviderLabel();
+  const modelName = getActiveModelName();
+  const providerSummary = modelName ? `${providerLabel} • ${modelName}` : providerLabel;
+  const providerSummaryHtml = escapeHtml(providerSummary);
 
   const title = isTechnical 
     ? 'Technical Summary Report' 
@@ -282,7 +296,7 @@ ${techOutput.mermaidDiagram}
     </div>
     ${bodyContent}
     <div class="footer">
-      <p>Powered by AI Content Suite & Gemini</p>
+      <p>Powered by AI Content Suite • ${providerSummaryHtml}</p>
     </div>
   </div>
   <script>
@@ -386,7 +400,10 @@ const generateMarkdownReport = (output: ProcessedOutput, mode: Mode, styleTarget
   }
 
   content += `---\n\n`;
-  content += `*Powered by AI Content Suite & Gemini*\n`;
+  const providerLabel = getActiveProviderLabel();
+  const modelName = getActiveModelName();
+  const providerSummary = modelName ? `${providerLabel} • ${modelName}` : providerLabel;
+  content += `*Powered by AI Content Suite • ${providerSummary}*\n`;
 
   return content;
 };

--- a/services/vectorStoreService.ts
+++ b/services/vectorStoreService.ts
@@ -1,0 +1,189 @@
+import type { EmbeddingSettings, VectorStoreMatch, VectorStoreSettings } from '../types';
+import { getEmbeddingProviderDefaultEndpoint } from './providerRegistry';
+
+const DEFAULT_QDRANT_TOP_K = 5;
+const MAX_QDRANT_TOP_K = 20;
+
+const getEmbeddingEndpoint = (embedding: EmbeddingSettings): string | null => {
+  const customEndpoint = embedding.baseUrl?.trim();
+  if (customEndpoint) {
+    return customEndpoint;
+  }
+  const defaultEndpoint = getEmbeddingProviderDefaultEndpoint(embedding.provider)?.trim();
+  if (defaultEndpoint) {
+    return defaultEndpoint;
+  }
+  return null;
+};
+
+const buildEmbeddingHeaders = (embedding: EmbeddingSettings): Record<string, string> => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = embedding.apiKey?.trim();
+  if (embedding.provider !== 'ollama' && apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  if (embedding.provider === 'openrouter') {
+    const referer = typeof window !== 'undefined' ? window.location.origin : 'https://local.app';
+    headers['HTTP-Referer'] = referer;
+    headers['X-Title'] = 'AI Content Suite';
+  }
+  return headers;
+};
+
+const requestEmbedding = async (text: string, embedding: EmbeddingSettings, signal?: AbortSignal): Promise<number[]> => {
+  const endpoint = getEmbeddingEndpoint(embedding);
+  if (!endpoint) {
+    throw new Error('No embedding endpoint configured for the selected provider.');
+  }
+
+  const headers = buildEmbeddingHeaders(embedding);
+  const body: Record<string, unknown> = { model: embedding.model.trim() };
+
+  if (!body.model) {
+    throw new Error('An embedding model is required to query the vector store.');
+  }
+
+  if (embedding.provider === 'ollama') {
+    body.prompt = text;
+  } else {
+    body.input = text;
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Embedding request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (embedding.provider === 'ollama') {
+    const vector = data?.embedding;
+    if (!Array.isArray(vector)) {
+      throw new Error('Ollama returned an unexpected embedding payload.');
+    }
+    return vector.map((value: unknown) => Number(value));
+  }
+
+  const vector = data?.data?.[0]?.embedding;
+  if (!Array.isArray(vector)) {
+    throw new Error('Embedding provider did not return a valid vector.');
+  }
+  return vector.map((value: unknown) => Number(value));
+};
+
+const buildQdrantHeaders = (apiKey?: string): Record<string, string> => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey && apiKey.trim() !== '') {
+    headers['api-key'] = apiKey.trim();
+  }
+  return headers;
+};
+
+const extractPayloadText = (payload: unknown): { text: string | null; metadata?: Record<string, unknown> } => {
+  if (!payload || typeof payload !== 'object') {
+    if (typeof payload === 'string') {
+      return { text: payload };
+    }
+    return { text: null };
+  }
+
+  const payloadRecord = payload as Record<string, unknown>;
+  const candidateKeys = ['text', 'content', 'chunk', 'document', 'body', 'summary'];
+
+  for (const key of candidateKeys) {
+    const value = payloadRecord[key];
+    if (typeof value === 'string' && value.trim() !== '') {
+      const metadata = { ...payloadRecord };
+      delete metadata[key];
+      return { text: value, metadata: Object.keys(metadata).length > 0 ? metadata : undefined };
+    }
+    if (Array.isArray(value) && value.every(item => typeof item === 'string')) {
+      const joined = (value as string[]).join('\n');
+      const metadata = { ...payloadRecord };
+      delete metadata[key];
+      return { text: joined, metadata: Object.keys(metadata).length > 0 ? metadata : undefined };
+    }
+  }
+
+  return { text: JSON.stringify(payloadRecord) };
+};
+
+const queryQdrant = async (
+  settings: VectorStoreSettings,
+  embeddingVector: number[],
+  signal?: AbortSignal,
+): Promise<VectorStoreMatch[]> => {
+  const baseUrl = (settings.url || '').trim().replace(/\/$/, '');
+  const collection = (settings.collection || '').trim();
+
+  if (!baseUrl || !collection) {
+    throw new Error('Qdrant URL and collection are required to fetch context.');
+  }
+
+  const searchUrl = `${baseUrl}/collections/${encodeURIComponent(collection)}/points/search`;
+  const limit = Math.min(Math.max(Math.round(settings.topK || DEFAULT_QDRANT_TOP_K), 1), MAX_QDRANT_TOP_K);
+
+  const response = await fetch(searchUrl, {
+    method: 'POST',
+    headers: buildQdrantHeaders(settings.apiKey),
+    body: JSON.stringify({
+      vector: embeddingVector,
+      limit,
+      with_payload: true,
+      with_vectors: false,
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Qdrant search failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const results = Array.isArray(data?.result) ? data.result : [];
+
+  return results
+    .map((item: any) => {
+      const score = typeof item?.score === 'number' ? item.score : 0;
+      const payload = extractPayloadText(item?.payload);
+      if (!payload.text) {
+        return null;
+      }
+      return {
+        text: payload.text,
+        score,
+        metadata: payload.metadata,
+      } as VectorStoreMatch;
+    })
+    .filter((match): match is VectorStoreMatch => Boolean(match));
+};
+
+export const fetchVectorStoreContext = async (
+  text: string,
+  settings: VectorStoreSettings,
+  signal?: AbortSignal,
+): Promise<VectorStoreMatch[]> => {
+  if (!settings.enabled) {
+    return [];
+  }
+
+  const trimmedText = text.trim();
+  if (!trimmedText) {
+    return [];
+  }
+
+  try {
+    const vector = await requestEmbedding(trimmedText, settings.embedding, signal);
+    return await queryQdrant(settings, vector, signal);
+  } catch (error) {
+    console.warn('Vector store lookup failed:', error);
+    return [];
+  }
+};

--- a/types.ts
+++ b/types.ts
@@ -314,15 +314,62 @@ export interface SavedPrompt {
   prompt: string;
 }
 
+export type AIProviderId = 'xai' | 'openrouter' | 'openai' | 'deepseek' | 'anthropic' | 'ollama';
+
+export type EmbeddingProviderId = 'openai' | 'openrouter' | 'deepseek' | 'ollama' | 'custom';
+
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+export type ProviderApiKeys = Partial<Record<AIProviderId, string>>;
+
+export interface EmbeddingSettings {
+  provider: EmbeddingProviderId;
+  model: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface VectorStoreSettings {
+  enabled: boolean;
+  url: string;
+  apiKey?: string;
+  collection: string;
+  topK: number;
+  embedding: EmbeddingSettings;
+}
+
+export interface VectorStoreMatch {
+  text: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AIProviderSettings {
+  selectedProvider: AIProviderId;
+  selectedModel: string;
+  apiKeys: ProviderApiKeys;
+}
+
 export interface ChatSettings {
   systemInstruction: string;
+  vectorStore?: VectorStoreSettings;
 }
 
 export type ChatMessagePart = { text: string } | { inlineData: { mimeType: string; data: string } };
 
+export interface ThinkingSegment {
+  type?: string;
+  label: string;
+  text: string;
+}
+
 export interface ChatMessage {
     role: 'user' | 'model';
     parts: ChatMessagePart[];
+    thinking?: ThinkingSegment[];
 }
 
 export interface ChatOutput {

--- a/utils/fileUtils.ts
+++ b/utils/fileUtils.ts
@@ -13,10 +13,10 @@ export const readFileAsText = (file: File): Promise<string> => {
 };
 
 /**
- * Converts a File object to a Gemini GenerativePart.
+ * Converts a File object to a provider-agnostic chat message part.
  * Handles images by converting to base64 and other files as text.
  * @param file The file to convert.
- * @returns A promise that resolves to a GenerativePart object.
+ * @returns A promise that resolves to a message part object understood by supported providers.
  */
 export const fileToGenerativePart = async (file: File): Promise<any> => {
     if (file.type.startsWith('image/')) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,12 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const defaultApiKey = env.AI_CONTENT_SUITE_DEFAULT_API_KEY ?? env.API_KEY ?? '';
     return {
       plugins: [react()],
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.API_KEY': JSON.stringify(defaultApiKey),
+        'process.env.AI_CONTENT_SUITE_DEFAULT_API_KEY': JSON.stringify(defaultApiKey),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- extract provider transport and reasoning normalization into a dedicated providerClient service so responses capture thinking segments without bloating geminiService
- extend chat message models and submission flow to persist thinking traces from providers and surface them alongside final answers
- enhance the chat viewer with a collapsible "Model thinking" panel, copy support, and status indicators so GPT-5 style streams no longer disappear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce30c6f99c832694fdbf73bbd102f0