### PR TITLE
Refine workspace persistence and layout controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ View your app in AI Studio: https://ai.studio/apps/drive/1AAdFi9Y_nFooagUjpfxZdO
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+2. Run the app:
    `npm run dev`
+3. In the app, open **Manage AI Settings** and add API keys for the providers you plan to use (OpenAI, OpenRouter, xAI, DeepSeek, Anthropic, or Ollama). Keys are stored locally in your browser.

--- a/components/layouts/ChatInterface.tsx
+++ b/components/layouts/ChatInterface.tsx
@@ -8,7 +8,7 @@ import { PaperclipIcon } from '../icons/PaperclipIcon';
 import { CogIcon } from '../icons/CogIcon';
 import { XCircleIcon } from '../icons/XCircleIcon';
 
-interface ChatInterfaceProps {
+export interface ChatInterfaceProps {
     history: ChatMessage[];
     isStreaming: boolean;
     chatInput: string;

--- a/components/layouts/MainForm.tsx
+++ b/components/layouts/MainForm.tsx
@@ -13,7 +13,7 @@ import { AgentDesignerControls } from '../views/controls/AgentDesignerControls';
 import { FileLoader } from '../ui/FileLoader';
 
 // A large props object, but necessary to delegate state from App.tsx
-interface MainFormProps {
+export interface MainFormProps {
     activeMode: Mode;
     currentFiles: File[] | null;
     // Technical Summarizer Props

--- a/components/layouts/ResultsViewer.tsx
+++ b/components/layouts/ResultsViewer.tsx
@@ -12,7 +12,7 @@ import { CheckCircleIcon } from '../icons/CheckCircleIcon';
 import { DownloadIcon } from '../icons/DownloadIcon';
 import { RESET_BUTTON_TEXT } from '../../constants/uiConstants';
 
-interface ResultsViewerProps {
+export interface ResultsViewerProps {
     processedData: ProcessedOutput;
     activeMode: Mode;
     scaffolderSettings: ScaffolderSettings;

--- a/components/layouts/Sidebar.tsx
+++ b/components/layouts/Sidebar.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import type { Mode } from '../../types';
+import { TABS } from '../../constants/uiConstants';
+
+type SidebarProps = {
+  collapsed: boolean;
+  onToggle: () => void;
+  activeMode: Mode;
+  onSelectMode?: (mode: Mode) => void;
+};
+
+const NAV_SECTIONS = [
+  {
+    title: 'Workspace',
+    modes: ['technical', 'styleExtractor', 'rewriter', 'mathFormatter', 'reasoningStudio', 'scaffolder'] as Mode[],
+  },
+  {
+    title: 'Orchestration',
+    modes: ['requestSplitter', 'promptEnhancer', 'agentDesigner'] as Mode[],
+  },
+  {
+    title: 'Interactive',
+    modes: ['chat'] as Mode[],
+  },
+];
+
+export const Sidebar: React.FC<SidebarProps> = ({ collapsed, onToggle, activeMode, onSelectMode }) => {
+  return (
+    <aside
+      className={`hidden md:flex flex-col border-r border-border-color/70 bg-surface/80 backdrop-blur-sm transition-all duration-300 ease-in-out ${
+        collapsed ? 'w-16' : 'w-64'
+      }`}
+      aria-label="Workspace navigation"
+    >
+      <div className="flex items-center justify-between px-3 py-4 border-b border-border-color/60">
+        <span className={`text-xs font-semibold uppercase tracking-widest text-text-secondary transition-opacity ${collapsed ? 'opacity-0' : 'opacity-80'}`}>
+          AI Suite
+        </span>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex h-8 w-8 items-center justify-center rounded-md border border-border-color/80 bg-secondary/60 text-text-secondary hover:text-text-primary hover:border-border-color transition-colors"
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
+        >
+          <span className="text-lg" aria-hidden="true">
+            {collapsed ? '»' : '«'}
+          </span>
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {NAV_SECTIONS.map(section => (
+          <div key={section.title} className="px-2 py-4">
+            <p className={`text-[0.65rem] uppercase tracking-widest text-text-secondary/70 mb-3 ${collapsed ? 'hidden' : 'block'}`}>
+              {section.title}
+            </p>
+            <ul className="space-y-1">
+              {section.modes.map(mode => {
+                const tab = TABS.find(tabItem => tabItem.id === mode);
+                if (!tab) return null;
+                const isActive = activeMode === mode;
+
+                return (
+                  <li key={mode}>
+                    <button
+                      type="button"
+                      onClick={() => onSelectMode?.(mode)}
+                      className={`w-full rounded-md px-2 py-2 text-left text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 focus:ring-offset-surface ${
+                        isActive
+                          ? 'bg-primary/20 text-text-primary border border-primary/40'
+                          : 'text-text-secondary hover:text-text-primary hover:bg-secondary/60'
+                      } ${collapsed ? 'justify-center text-[0.65rem] px-0 py-1.5' : ''}`}
+                    >
+                      {collapsed ? tab.label[0] : tab.label}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <div className={`px-3 py-4 text-xs text-text-secondary/70 border-t border-border-color/60 ${collapsed ? 'hidden' : 'block'}`}>
+        Future modules and team dashboards will appear here.
+      </div>
+    </aside>
+  );
+};

--- a/components/layouts/WorkspaceLayout.tsx
+++ b/components/layouts/WorkspaceLayout.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import type { Mode, ProcessingError } from '../../types';
+import type { AppState, ProgressUpdate } from '../../types';
+import { Sidebar } from './Sidebar';
+import { Tabs } from '../ui/Tabs';
+import { ChatInterface, ChatInterfaceProps } from './ChatInterface';
+import { MainForm, MainFormProps } from './MainForm';
+import { SubmitButton } from '../ui/SubmitButton';
+import { StopButton } from '../ui/StopButton';
+import { ResultsViewer, ResultsViewerProps } from './ResultsViewer';
+import { ProgressBar } from '../ui/ProgressBar';
+import { DESCRIPTION_TEXT, TABS } from '../../constants/uiConstants';
+import { XCircleIcon } from '../icons/XCircleIcon';
+
+interface WorkspaceLayoutProps {
+  activeMode: Mode;
+  sidebarProps: React.ComponentProps<typeof Sidebar>;
+  onModeChange: (mode: Mode) => void;
+  headerProps: {
+    isSidebarCollapsed: boolean;
+    onToggleSidebar: () => void;
+    activeProviderLabel: string;
+    activeModelName: string;
+  };
+  layoutControls: {
+    contentWidthLabel: string;
+    contentWidthPercent: number;
+    onWidthPercentChange: (value: number) => void;
+    appliedContentWidth: string;
+  };
+  providerBanner: {
+    activeProviderLabel: string;
+    activeModelName: string;
+    statusText: string;
+    statusTone: string;
+    onManageSettings: () => void;
+  };
+  showChat: boolean;
+  chatProps?: ChatInterfaceProps;
+  showMainForm: boolean;
+  mainFormProps?: MainFormProps;
+  showSubmitButton: boolean;
+  buttonText: string;
+  onSubmit: () => void;
+  appState: AppState;
+  progress: ProgressUpdate;
+  onStop: () => void;
+  showResults: boolean;
+  resultsProps?: ResultsViewerProps;
+  showError: boolean;
+  error?: ProcessingError | null;
+  onErrorReset: () => void;
+  providerSummaryText: string;
+}
+
+export const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({
+  activeMode,
+  sidebarProps,
+  onModeChange,
+  headerProps,
+  layoutControls,
+  providerBanner,
+  showChat,
+  chatProps,
+  showMainForm,
+  mainFormProps,
+  showSubmitButton,
+  buttonText,
+  onSubmit,
+  appState,
+  progress,
+  onStop,
+  showResults,
+  resultsProps,
+  showError,
+  error,
+  onErrorReset,
+  providerSummaryText,
+}) => {
+  const description = DESCRIPTION_TEXT[activeMode];
+  const isProcessing = appState === 'processing';
+
+  return (
+    <div className="relative min-h-screen flex bg-transparent text-text-primary">
+      <Sidebar {...sidebarProps} />
+      <div className="flex-1 flex flex-col">
+        <header className="flex items-center justify-between border-b border-border-color/70 bg-surface/70 px-4 py-3 sm:px-6">
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={headerProps.onToggleSidebar}
+              className="md:hidden rounded-md border border-border-color/60 px-3 py-2 text-xs font-semibold uppercase tracking-widest text-text-secondary hover:text-text-primary"
+              aria-label={headerProps.isSidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'}
+            >
+              Menu
+            </button>
+            <div className="text-left">
+              <h1 className="text-xl font-semibold text-text-primary">AI Content Suite</h1>
+              <p className="text-xs text-text-secondary">Unified workspace for advanced content tooling</p>
+            </div>
+          </div>
+          <div className="hidden sm:flex flex-col items-end text-xs text-text-secondary">
+            <span>
+              Active provider: <span className="text-text-primary font-semibold">{headerProps.activeProviderLabel}</span>
+            </span>
+            <span>
+              Model: <span className="text-text-primary font-medium">{headerProps.activeModelName || 'Select a model'}</span>
+            </span>
+          </div>
+        </header>
+
+        <main className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-10 py-6">
+          <div className="mx-auto flex flex-col gap-4" style={{ width: layoutControls.appliedContentWidth, maxWidth: '100%' }}>
+            <div className="rounded-lg border border-border-color/60 bg-secondary/60 px-4 py-3">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-widest text-text-secondary">Workspace width</p>
+                  <p className="text-sm font-medium text-text-primary">{layoutControls.contentWidthLabel}</p>
+                </div>
+                <div className="flex items-center gap-2 w-full sm:w-auto">
+                  <span className="text-xs text-text-secondary">Compact</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    value={layoutControls.contentWidthPercent}
+                    onChange={event => layoutControls.onWidthPercentChange(Number(event.target.value))}
+                    className="flex-1 sm:w-48 accent-primary"
+                    aria-label="Adjust workspace width"
+                  />
+                  <span className="text-xs text-text-secondary">Full</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-surface shadow-2xl rounded-lg border border-border-color animate-breathing-glow p-6 sm:p-8">
+              <header className="mb-6 text-center">
+                <h2 className="text-3xl sm:text-4xl font-bold text-text-primary">AI Content Suite</h2>
+                <p className="text-text-secondary mt-2 text-sm sm:text-base">{description}</p>
+              </header>
+
+              <div className="mb-6">
+                <Tabs tabs={TABS} activeTabId={activeMode} onTabChange={id => onModeChange(id as Mode)} />
+              </div>
+
+              <div className="mb-6 bg-secondary/60 border border-border-color rounded-lg px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3 text-text-secondary">
+                  <span className="text-text-primary font-semibold">Active provider:</span>
+                  <span className="text-text-primary font-medium">{providerBanner.activeProviderLabel}</span>
+                  <span className="hidden sm:inline text-text-secondary">•</span>
+                  <span className="text-text-primary font-medium">{providerBanner.activeModelName || 'Select a model'}</span>
+                </div>
+                <div className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs sm:text-sm">
+                  <span className={`font-medium ${providerBanner.statusTone}`}>{providerBanner.statusText}</span>
+                  <button
+                    type="button"
+                    onClick={providerBanner.onManageSettings}
+                    className="px-4 py-2 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary-hover transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
+                  >
+                    Manage AI Settings
+                  </button>
+                </div>
+              </div>
+
+              {showChat && chatProps ? (
+                <ChatInterface {...chatProps} />
+              ) : showMainForm && mainFormProps ? (
+                <MainForm {...mainFormProps} />
+              ) : null}
+
+              {showSubmitButton && (
+                <SubmitButton onClick={onSubmit} disabled={isProcessing} appState={appState} buttonText={buttonText} />
+              )}
+
+              {isProcessing && (
+                <div className="mt-8">
+                  <ProgressBar progress={progress} />
+                  <StopButton onClick={onStop} />
+                </div>
+              )}
+
+              {showResults && resultsProps && (
+                <ResultsViewer {...resultsProps} />
+              )}
+
+              {showError && error && (
+                <div className="mt-8 p-4 bg-red-900 border border-red-700 rounded-lg text-red-100 animate-fade-in-scale" role="alert">
+                  <div className="flex items-center mb-2">
+                    <XCircleIcon className="w-6 h-6 mr-2" aria-hidden="true" />
+                    <h3 className="text-lg font-semibold">Error</h3>
+                  </div>
+                  <p className="text-sm">{error.message}</p>
+                  {error.details && (
+                    <details className="mt-2 text-xs">
+                      <summary>Show Details</summary>
+                      <pre className="whitespace-pre-wrap break-all bg-red-800 p-2 rounded mt-1">{error.details}</pre>
+                    </details>
+                  )}
+                  <button
+                    onClick={onErrorReset}
+                    className="mt-4 w-full px-6 py-2 bg-red-700 text-white font-semibold rounded-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-surface"
+                  >
+                    Try Again
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </main>
+
+        <footer className="px-6 pb-6 text-center text-xs text-text-secondary">
+          <p>&copy; {new Date().getFullYear()} AI Content Suite. Powered by {providerSummaryText}.</p>
+        </footer>
+      </div>
+    </div>
+  );
+};

--- a/components/modals/ChatSettingsModal.tsx
+++ b/components/modals/ChatSettingsModal.tsx
@@ -1,7 +1,24 @@
-
-
-import React, { useState, useEffect, MouseEvent } from 'react';
-import type { ChatSettings, SavedPrompt } from '../../types';
+import React, { useState, useEffect, useCallback, useRef, MouseEvent } from 'react';
+import type {
+  ChatSettings,
+  SavedPrompt,
+  AIProviderSettings,
+  AIProviderId,
+  ModelOption,
+  VectorStoreSettings,
+  EmbeddingProviderId,
+} from '../../types';
+import type { ProviderInfo, EmbeddingProviderInfo } from '../../services/providerRegistry';
+import {
+  DEFAULT_PROVIDER_MODELS,
+  DEFAULT_EMBEDDING_MODELS,
+  INITIAL_CHAT_SETTINGS,
+} from '../../constants';
+import {
+  EMBEDDING_PROVIDERS,
+  requiresEmbeddingApiKey,
+  getEmbeddingProviderDefaultEndpoint,
+} from '../../services/providerRegistry';
 import { XCircleIcon } from '../icons/XCircleIcon';
 import { TrashIcon } from '../icons/TrashIcon';
 
@@ -9,25 +26,264 @@ interface ChatSettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   currentSettings: ChatSettings;
-  onSave: (newSettings: ChatSettings) => void;
+  providerSettings: AIProviderSettings;
+  providers: ProviderInfo[];
+  onSave: (newSettings: ChatSettings, providerSettings: AIProviderSettings) => void;
+  onFetchModels: (providerId: AIProviderId, apiKey?: string) => Promise<ModelOption[]>;
   savedPrompts: SavedPrompt[];
   onSavePreset: (name: string, prompt: string) => void;
   onDeletePreset: (name: string) => void;
 }
 
-export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({ isOpen, onClose, currentSettings, onSave, savedPrompts, onSavePreset, onDeletePreset }) => {
-  const [editedSettings, setEditedSettings] = useState<ChatSettings>(currentSettings);
+const ensureVectorStoreSettings = (vectorStore?: VectorStoreSettings): VectorStoreSettings => {
+  const defaults = INITIAL_CHAT_SETTINGS.vectorStore!;
+  return {
+    ...defaults,
+    ...(vectorStore ?? {}),
+    embedding: {
+      ...defaults.embedding,
+      ...(vectorStore?.embedding ?? {}),
+    },
+  };
+};
+
+const withDefaults = (settings: ChatSettings): ChatSettings => ({
+  ...settings,
+  vectorStore: ensureVectorStoreSettings(settings.vectorStore),
+});
+
+export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
+  isOpen,
+  onClose,
+  currentSettings,
+  providerSettings,
+  providers,
+  onSave,
+  onFetchModels,
+  savedPrompts,
+  onSavePreset,
+  onDeletePreset,
+}) => {
+  const [editedSettings, setEditedSettings] = useState<ChatSettings>(() => withDefaults(currentSettings));
+  const [editedProviderSettings, setEditedProviderSettings] = useState<AIProviderSettings>(providerSettings);
+  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelsError, setModelsError] = useState<string | null>(null);
   const [selectedPreset, setSelectedPreset] = useState<string>(''); // Holds the name of the selected preset
+  const loadRequestIdRef = useRef(0);
+
+  const updateVectorStore = useCallback((updater: (prev: VectorStoreSettings) => VectorStoreSettings) => {
+    setEditedSettings(prev => {
+      const currentVector = ensureVectorStoreSettings(prev.vectorStore);
+      return {
+        ...prev,
+        vectorStore: updater(currentVector),
+      };
+    });
+  }, []);
+
+  const loadModels = useCallback(async (providerId: AIProviderId, apiKey?: string) => {
+    const providerInfo = providers.find(p => p.id === providerId);
+    const trimmedKey = apiKey?.trim();
+
+    if (providerInfo?.requiresApiKey && !trimmedKey) {
+      setModelOptions([]);
+      setModelsError(`${providerInfo.label} requires an API key to load models.`);
+      setModelsLoading(false);
+      return;
+    }
+
+    const requestId = ++loadRequestIdRef.current;
+    setModelsLoading(true);
+    setModelsError(null);
+    setModelOptions([]);
+
+    try {
+      const models = await onFetchModels(providerId, trimmedKey);
+      if (loadRequestIdRef.current !== requestId) {
+        return;
+      }
+      setModelOptions(models);
+      if (models.length > 0) {
+        setEditedProviderSettings(prev => {
+          if (prev.selectedProvider !== providerId) return prev;
+          if (models.some(model => model.id === prev.selectedModel)) {
+            return prev;
+          }
+          return { ...prev, selectedModel: models[0].id };
+        });
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      setModelsError(message);
+      setModelOptions([]);
+    } finally {
+      if (loadRequestIdRef.current === requestId) {
+        setModelsLoading(false);
+      }
+    }
+  }, [onFetchModels, providers]);
 
   useEffect(() => {
     if (isOpen) {
-      setEditedSettings(currentSettings);
+      setEditedSettings(withDefaults(currentSettings));
+      setEditedProviderSettings(providerSettings);
+      setModelOptions([]);
+      setModelsError(null);
+      setModelsLoading(false);
       setSelectedPreset(''); // Reset selection when opening
     }
-  }, [isOpen, currentSettings]);
+  }, [isOpen, currentSettings, providerSettings]);
+
+  useEffect(() => {
+    if (isOpen) {
+      const providerId = providerSettings.selectedProvider;
+      const apiKey = providerSettings.apiKeys?.[providerId];
+      loadModels(providerId, apiKey);
+    }
+  }, [isOpen, providerSettings, loadModels]);
 
   const handleSave = () => {
-    onSave(editedSettings);
+    const providerId = editedProviderSettings.selectedProvider;
+    const trimmedModel = editedProviderSettings.selectedModel.trim();
+    const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? DEFAULT_PROVIDER_MODELS[providerSettings.selectedProvider];
+    const sanitizedApiKeys = Object.entries(editedProviderSettings.apiKeys || {}).reduce<AIProviderSettings['apiKeys']>((acc, [key, value]) => {
+      const trimmed = typeof value === 'string' ? value.trim() : value;
+      if (trimmed) {
+        acc[key] = trimmed;
+      }
+      return acc;
+    }, {});
+
+    const draftVectorStore = ensureVectorStoreSettings(editedSettings.vectorStore);
+    const parsedTopK = Number(draftVectorStore.topK);
+    const sanitizedTopK = Number.isFinite(parsedTopK) && parsedTopK > 0 ? Math.min(Math.round(parsedTopK), 20) : 5;
+    const sanitizedVectorStore: VectorStoreSettings = {
+      enabled: Boolean(draftVectorStore.enabled),
+      url: (draftVectorStore.url || '').trim(),
+      apiKey: draftVectorStore.apiKey && draftVectorStore.apiKey.trim() !== '' ? draftVectorStore.apiKey.trim() : undefined,
+      collection: (draftVectorStore.collection || '').trim(),
+      topK: sanitizedTopK,
+      embedding: {
+        provider: draftVectorStore.embedding.provider,
+        model: draftVectorStore.embedding.model.trim(),
+        apiKey:
+          draftVectorStore.embedding.apiKey && draftVectorStore.embedding.apiKey.trim() !== ''
+            ? draftVectorStore.embedding.apiKey.trim()
+            : undefined,
+        baseUrl:
+          draftVectorStore.embedding.baseUrl && draftVectorStore.embedding.baseUrl.trim() !== ''
+            ? draftVectorStore.embedding.baseUrl.trim()
+            : undefined,
+      },
+    };
+
+    const finalProviderSettings: AIProviderSettings = {
+      selectedProvider: providerId,
+      selectedModel: trimmedModel || fallbackModel,
+      apiKeys: sanitizedApiKeys,
+    };
+
+    const finalChatSettings: ChatSettings = {
+      ...editedSettings,
+      vectorStore: sanitizedVectorStore,
+    };
+
+    onSave(finalChatSettings, finalProviderSettings);
+  };
+
+  const handleProviderChange = (providerId: AIProviderId) => {
+    setEditedProviderSettings(prev => {
+      const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? prev.selectedModel;
+      return {
+        ...prev,
+        selectedProvider: providerId,
+        selectedModel: fallbackModel,
+      };
+    });
+    const apiKey = editedProviderSettings.apiKeys?.[providerId];
+    loadModels(providerId, apiKey);
+  };
+
+  const handleApiKeyChange = (providerId: AIProviderId, value: string) => {
+    setEditedProviderSettings(prev => ({
+      ...prev,
+      apiKeys: { ...prev.apiKeys, [providerId]: value },
+    }));
+  };
+
+  const handleModelInputChange = (value: string) => {
+    setEditedProviderSettings(prev => ({
+      ...prev,
+      selectedModel: value,
+    }));
+  };
+
+  const handleVectorStoreEnabledChange = (enabled: boolean) => {
+    updateVectorStore(prev => ({ ...prev, enabled }));
+  };
+
+  const handleVectorStoreUrlChange = (value: string) => {
+    updateVectorStore(prev => ({ ...prev, url: value }));
+  };
+
+  const handleVectorStoreCollectionChange = (value: string) => {
+    updateVectorStore(prev => ({ ...prev, collection: value }));
+  };
+
+  const handleVectorStoreApiKeyChange = (value: string) => {
+    updateVectorStore(prev => ({ ...prev, apiKey: value }));
+  };
+
+  const handleVectorStoreTopKChange = (value: string) => {
+    const numericValue = Number(value);
+    updateVectorStore(prev => ({
+      ...prev,
+      topK: value === '' ? 0 : Number.isFinite(numericValue) ? numericValue : prev.topK,
+    }));
+  };
+
+  const handleEmbeddingProviderChange = (providerId: EmbeddingProviderId) => {
+    updateVectorStore(prev => {
+      if (prev.embedding.provider === providerId) {
+        return { ...prev, embedding: { ...prev.embedding, provider: providerId } };
+      }
+      const defaultModel = DEFAULT_EMBEDDING_MODELS[providerId] ?? '';
+      const defaultEndpoint = getEmbeddingProviderDefaultEndpoint(providerId) ?? '';
+      return {
+        ...prev,
+        embedding: {
+          ...prev.embedding,
+          provider: providerId,
+          model: defaultModel,
+          baseUrl: providerId === 'custom' ? '' : defaultEndpoint,
+        },
+      };
+    });
+  };
+
+  const handleEmbeddingModelChange = (value: string) => {
+    updateVectorStore(prev => ({
+      ...prev,
+      embedding: { ...prev.embedding, model: value },
+    }));
+  };
+
+  const handleEmbeddingApiKeyChange = (value: string) => {
+    updateVectorStore(prev => ({
+      ...prev,
+      embedding: { ...prev.embedding, apiKey: value },
+    }));
+  };
+
+  const handleEmbeddingBaseUrlChange = (value: string) => {
+    updateVectorStore(prev => ({
+      ...prev,
+      embedding: { ...prev.embedding, baseUrl: value },
+    }));
   };
 
   const handleLoadPreset = (name: string) => {
@@ -61,6 +317,19 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({ isOpen, on
     }
   };
 
+  const selectedProviderInfo = providers.find(p => p.id === editedProviderSettings.selectedProvider);
+  const selectedApiKey = editedProviderSettings.apiKeys?.[editedProviderSettings.selectedProvider] ?? '';
+  const vectorStoreSettings = editedSettings.vectorStore ?? ensureVectorStoreSettings();
+  const embeddingSettings = vectorStoreSettings.embedding;
+  const selectedEmbeddingProviderInfo = EMBEDDING_PROVIDERS.find(p => p.id === embeddingSettings.provider) as
+    | EmbeddingProviderInfo
+    | undefined;
+  const embeddingEndpointPlaceholder =
+    embeddingSettings.provider === 'custom'
+      ? 'https://your-embedding-endpoint/v1/embeddings'
+      : getEmbeddingProviderDefaultEndpoint(embeddingSettings.provider) ?? '';
+  const embeddingRequiresApiKey = requiresEmbeddingApiKey(embeddingSettings.provider);
+
   if (!isOpen) return null;
 
   return (
@@ -81,11 +350,266 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({ isOpen, on
         
         <div className="p-6 sm:p-8 space-y-4">
             <div>
+              <label htmlFor="provider-selector" className="block text-sm font-medium text-text-secondary mb-2">
+                AI Provider
+              </label>
+              <select
+                id="provider-selector"
+                value={editedProviderSettings.selectedProvider}
+                onChange={(e) => handleProviderChange(e.target.value as AIProviderId)}
+                className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
+              >
+                {providers.map(provider => (
+                  <option key={provider.id} value={provider.id}>{provider.label}</option>
+                ))}
+              </select>
+              {selectedProviderInfo?.docsUrl && (
+                <p className="mt-1 text-xs text-text-secondary">
+                  API docs:{' '}
+                  <a href={selectedProviderInfo.docsUrl} target="_blank" rel="noreferrer" className="text-primary underline">
+                    {selectedProviderInfo.docsUrl}
+                  </a>
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label htmlFor="provider-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                API Key
+              </label>
+              <input
+                id="provider-api-key"
+                type="password"
+                value={selectedApiKey}
+                onChange={(e) => handleApiKeyChange(editedProviderSettings.selectedProvider, e.target.value)}
+                placeholder={selectedProviderInfo?.requiresApiKey ? 'Enter your API key' : 'Optional for this provider'}
+                className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+              />
+              <p className="mt-1 text-xs text-text-secondary">
+                {selectedProviderInfo?.requiresApiKey
+                  ? 'Required to authenticate requests.'
+                  : 'Optional. Leave blank for local deployments.'}
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="provider-model" className="block text-sm font-medium text-text-secondary mb-2">
+                Model
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="provider-model"
+                  type="text"
+                  list="provider-model-options"
+                  value={editedProviderSettings.selectedModel}
+                  onChange={(e) => handleModelInputChange(e.target.value)}
+                  placeholder="Select or enter a model name"
+                  className="flex-grow px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                />
+                <button
+                  type="button"
+                  onClick={() => loadModels(editedProviderSettings.selectedProvider, selectedApiKey)}
+                  className="px-3 py-2 bg-muted text-text-primary font-medium rounded-md hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary disabled:opacity-50"
+                  disabled={modelsLoading}
+                >
+                  {modelsLoading ? 'Loading...' : 'Refresh'}
+                </button>
+              </div>
+              <datalist id="provider-model-options">
+                {modelOptions.map(model => (
+                  <option key={model.id} value={model.id}>{model.label}</option>
+                ))}
+              </datalist>
+              {modelsError ? (
+                <p className="mt-1 text-xs text-destructive">{modelsError}</p>
+              ) : modelOptions.length > 0 ? (
+                <p className="mt-1 text-xs text-text-secondary">Choose a model from the suggestions or provide a custom value.</p>
+              ) : (
+                <p className="mt-1 text-xs text-text-secondary">Enter a model name or refresh to fetch available options.</p>
+              )}
+            </div>
+
+            <div className="border border-border-color rounded-lg p-4 space-y-4">
+              <div className="flex items-start gap-3">
+                <input
+                  id="vector-store-enabled"
+                  type="checkbox"
+                  checked={vectorStoreSettings.enabled}
+                  onChange={(e) => handleVectorStoreEnabledChange(e.target.checked)}
+                  className="mt-1 h-4 w-4 text-primary focus:ring-ring border-border-color rounded"
+                />
+                <div>
+                  <label htmlFor="vector-store-enabled" className="text-sm font-medium text-text-secondary">
+                    Enable Qdrant retrieval
+                  </label>
+                  <p className="mt-1 text-xs text-text-secondary">
+                    When enabled, chat requests will fetch relevant knowledge base entries from your centralized Qdrant
+                    collection and share them with the model before it responds.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="sm:col-span-2">
+                  <label htmlFor="vector-store-url" className="block text-sm font-medium text-text-secondary mb-2">
+                    Qdrant URL
+                  </label>
+                  <input
+                    id="vector-store-url"
+                    type="url"
+                    value={vectorStoreSettings.url}
+                    onChange={(e) => handleVectorStoreUrlChange(e.target.value)}
+                    placeholder="https://qdrant.yourcompany.com"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="vector-store-collection" className="block text-sm font-medium text-text-secondary mb-2">
+                    Collection name
+                  </label>
+                  <input
+                    id="vector-store-collection"
+                    type="text"
+                    value={vectorStoreSettings.collection}
+                    onChange={(e) => handleVectorStoreCollectionChange(e.target.value)}
+                    placeholder="knowledge-base"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="vector-store-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                    Qdrant API key
+                  </label>
+                  <input
+                    id="vector-store-api-key"
+                    type="password"
+                    value={vectorStoreSettings.apiKey ?? ''}
+                    onChange={(e) => handleVectorStoreApiKeyChange(e.target.value)}
+                    placeholder="Optional"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                  <p className="mt-1 text-xs text-text-secondary">
+                    Leave blank if your cluster is secured by network rules. Provide a key for hosted deployments.
+                  </p>
+                </div>
+
+                <div>
+                  <label htmlFor="vector-store-topk" className="block text-sm font-medium text-text-secondary mb-2">
+                    Results per query (Top-k)
+                  </label>
+                  <input
+                    id="vector-store-topk"
+                    type="number"
+                    min={1}
+                    max={20}
+                    value={vectorStoreSettings.topK || ''}
+                    onChange={(e) => handleVectorStoreTopKChange(e.target.value)}
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <label htmlFor="embedding-provider" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding provider
+                  </label>
+                  <select
+                    id="embedding-provider"
+                    value={embeddingSettings.provider}
+                    onChange={(e) => handleEmbeddingProviderChange(e.target.value as EmbeddingProviderId)}
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  >
+                    {EMBEDDING_PROVIDERS.map(provider => (
+                      <option key={provider.id} value={provider.id}>
+                        {provider.label}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedEmbeddingProviderInfo?.docsUrl && (
+                    <p className="mt-1 text-xs text-text-secondary">
+                      API docs:{' '}
+                      <a
+                        href={selectedEmbeddingProviderInfo.docsUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary underline"
+                      >
+                        {selectedEmbeddingProviderInfo.docsUrl}
+                      </a>
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label htmlFor="embedding-model" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding model
+                  </label>
+                  <input
+                    id="embedding-model"
+                    type="text"
+                    value={embeddingSettings.model}
+                    onChange={(e) => handleEmbeddingModelChange(e.target.value)}
+                    placeholder="text-embedding-3-small"
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="embedding-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding API key
+                  </label>
+                  <input
+                    id="embedding-api-key"
+                    type="password"
+                    value={embeddingSettings.apiKey ?? ''}
+                    onChange={(e) => handleEmbeddingApiKeyChange(e.target.value)}
+                    placeholder={embeddingRequiresApiKey ? 'Required for this provider' : 'Optional'}
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                  <p className="mt-1 text-xs text-text-secondary">
+                    {embeddingRequiresApiKey
+                      ? 'Required to request embeddings from this provider.'
+                      : 'Optional. Local endpoints such as Ollama typically do not need an API key.'}
+                  </p>
+                </div>
+
+                <div>
+                  <label htmlFor="embedding-endpoint" className="block text-sm font-medium text-text-secondary mb-2">
+                    Embedding endpoint override
+                  </label>
+                  <input
+                    id="embedding-endpoint"
+                    type="url"
+                    value={embeddingSettings.baseUrl ?? ''}
+                    onChange={(e) => handleEmbeddingBaseUrlChange(e.target.value)}
+                    placeholder={embeddingEndpointPlaceholder || 'https://...' }
+                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                    disabled={!vectorStoreSettings.enabled}
+                  />
+                  <p className="mt-1 text-xs text-text-secondary">
+                    Leave blank to use the default endpoint for {selectedEmbeddingProviderInfo?.label ?? 'this provider'}.
+                    Provide a custom URL for self-hosted or proxy deployments.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div>
               <label htmlFor="preset-selector" className="block text-sm font-medium text-text-secondary mb-2">
                 Manage Presets
               </label>
               <div className="flex items-center gap-2">
-                <select 
+                <select
                   id="preset-selector"
                   value={selectedPreset}
                   onChange={(e) => handleLoadPreset(e.target.value)}

--- a/components/views/viewers/ScaffoldGraphView.tsx
+++ b/components/views/viewers/ScaffoldGraphView.tsx
@@ -1,0 +1,551 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ForceGraph2D, { type ForceGraphMethods, type GraphData, type LinkObject, type NodeObject } from 'react-force-graph-2d';
+import type { ScaffoldPlan, ScaffoldTreeItem } from '../../../types';
+
+export type GraphNodeType =
+    | 'project'
+    | 'layer'
+    | 'file'
+    | 'task'
+    | 'phase'
+    | 'subtask'
+    | 'validate'
+    | 'constraint';
+
+interface GraphNodePayload {
+    id: string;
+    label: string;
+    type: GraphNodeType;
+    detail?: string;
+    status?: string;
+    layer?: string;
+}
+
+interface GraphLinkPayload {
+    relation: string;
+    color: string;
+}
+
+type GraphNode = NodeObject<GraphNodePayload>;
+type GraphLink = LinkObject<GraphNodePayload, GraphLinkPayload>;
+
+type ScaffoldGraphData = GraphData<GraphNode, GraphLink>;
+
+const NODE_META: Record<GraphNodeType, { label: string; color: string; description: string }> = {
+    project: {
+        label: 'Project',
+        color: '#38bdf8',
+        description: 'High-level solution scope and constraints',
+    },
+    layer: {
+        label: 'Architecture Layer',
+        color: '#f97316',
+        description: 'Clean architecture layer that groups generated files',
+    },
+    file: {
+        label: 'File',
+        color: '#a855f7',
+        description: 'Generated source file with an associated prompt',
+    },
+    task: {
+        label: 'Goal',
+        color: '#22c55e',
+        description: 'Primary delivery goal within the scaffold plan',
+    },
+    phase: {
+        label: 'Phase',
+        color: '#eab308',
+        description: 'Milestone grouping the concrete build steps',
+    },
+    subtask: {
+        label: 'Build Step',
+        color: '#38bdf8',
+        description: 'Executable implementation task',
+    },
+    validate: {
+        label: 'Validation',
+        color: '#f87171',
+        description: 'Quality or constraint checks applied to build steps',
+    },
+    constraint: {
+        label: 'Constraint',
+        color: '#fbbf24',
+        description: 'Guardrail that keeps the scaffold within project limits',
+    },
+};
+
+const RELATION_COLORS: Record<string, string> = {
+    'enforces layer': '#f97316',
+    'contains file': '#a855f7',
+    'depends on': '#f43f5e',
+    'drives goal': '#22c55e',
+    'expands into phase': '#eab308',
+    'delivers output': '#38bdf8',
+    'validation step': '#f87171',
+    constraint: '#fbbf24',
+};
+
+const formatDetail = (detail?: string) => detail?.split('\n').filter(Boolean) ?? [];
+
+const buildDetailFromTreeItem = (file?: ScaffoldTreeItem) => {
+    if (!file) {
+        return 'File inferred from dependency graph';
+    }
+
+    return [
+        `Layer: ${file.layer}`,
+        `Purpose: ${file.purpose}`,
+    ].join('\n');
+};
+
+const sanitizeId = (value: string) => value.replace(/\s+/g, '-').toLowerCase();
+
+const buildGraphData = (plan: ScaffoldPlan): ScaffoldGraphData => {
+    const nodes: GraphNode[] = [];
+    const links: GraphLink[] = [];
+    const nodeLookup = new Map<string, GraphNode>();
+    const linkKeys = new Set<string>();
+    const treeByPath = new Map<string, ScaffoldTreeItem>();
+
+    plan.tree.forEach((item) => {
+        treeByPath.set(item.path, item);
+    });
+
+    const registerNode = (payload: GraphNodePayload): GraphNode => {
+        const existing = nodeLookup.get(payload.id);
+        if (existing) {
+            if (payload.detail && (!existing.detail || existing.detail === 'File inferred from dependency graph')) {
+                existing.detail = payload.detail;
+            }
+            existing.label = payload.label || existing.label;
+            existing.layer = payload.layer ?? existing.layer;
+            return existing;
+        }
+
+        const node = { ...payload } as GraphNode;
+        nodeLookup.set(payload.id, node);
+        nodes.push(node);
+        return node;
+    };
+
+    const registerLink = (payload: GraphLinkPayload & { source: string; target: string }) => {
+        const key = `${payload.source}->${payload.target}::${payload.relation}`;
+        if (linkKeys.has(key)) {
+            return;
+        }
+        linkKeys.add(key);
+        links.push({ source: payload.source, target: payload.target, relation: payload.relation, color: payload.color } as GraphLink);
+    };
+
+    const ensureLayerNode = (layer: string) =>
+        registerNode({
+            id: `layer:${sanitizeId(layer)}`,
+            label: layer,
+            type: 'layer',
+            detail: `Clean architecture layer: ${layer}`,
+        });
+
+    const ensureFileNode = (path: string) => {
+        const id = `file:${path}`;
+        const file = treeByPath.get(path);
+        return registerNode({
+            id,
+            label: path.split('/').pop() ?? path,
+            type: 'file',
+            detail: buildDetailFromTreeItem(file),
+            layer: file?.layer,
+        });
+    };
+
+    const projectId = `project:${sanitizeId(plan.project.name)}`;
+    registerNode({
+        id: projectId,
+        label: plan.project.name,
+        type: 'project',
+        detail: [
+            `Language: ${plan.project.language}`,
+            `Template: ${plan.project.template}`,
+            `Package manager: ${plan.project.packageManager}`,
+            `License: ${plan.project.license}`,
+        ].join('\n'),
+    });
+
+    if (plan.constraints) {
+        const constraintId = `constraint:${sanitizeId(plan.project.name)}`;
+        registerNode({
+            id: constraintId,
+            label: 'Constraints',
+            type: 'constraint',
+            detail: [
+                `Max LOC per file: ${plan.constraints.max_loc_per_file}`,
+                `Enforce layering: ${plan.constraints.enforce_layering ? 'yes' : 'no'}`,
+                `Repository pattern: ${plan.constraints.repository_pattern ? 'required' : 'optional'}`,
+                plan.constraints.framework_free_layers.length
+                    ? `Framework-free layers: ${plan.constraints.framework_free_layers.join(', ')}`
+                    : undefined,
+            ]
+                .filter(Boolean)
+                .join('\n'),
+        });
+        registerLink({ source: projectId, target: constraintId, relation: 'constraint', color: RELATION_COLORS.constraint });
+    }
+
+    plan.layers.forEach((layer) => {
+        const layerNode = ensureLayerNode(layer);
+        registerLink({
+            source: projectId,
+            target: layerNode.id as string,
+            relation: 'enforces layer',
+            color: RELATION_COLORS['enforces layer'],
+        });
+    });
+
+    plan.tree.forEach((file) => {
+        const layerNode = ensureLayerNode(file.layer);
+        const fileNode = ensureFileNode(file.path);
+        registerLink({
+            source: layerNode.id as string,
+            target: fileNode.id as string,
+            relation: 'contains file',
+            color: RELATION_COLORS['contains file'],
+        });
+    });
+
+    plan.dependencies.forEach((dependency) => {
+        const fromNode = ensureFileNode(dependency.from);
+        dependency.to.forEach((targetPath) => {
+            const targetNode = ensureFileNode(targetPath);
+            registerLink({
+                source: fromNode.id as string,
+                target: targetNode.id as string,
+                relation: 'depends on',
+                color: RELATION_COLORS['depends on'],
+            });
+        });
+    });
+
+    plan.tasks.forEach((task, taskIndex) => {
+        const taskId = `task:${taskIndex}`;
+        registerNode({
+            id: taskId,
+            label: task.goal,
+            type: 'task',
+            detail: `Phases: ${task.phases.length}`,
+        });
+        registerLink({
+            source: projectId,
+            target: taskId,
+            relation: 'drives goal',
+            color: RELATION_COLORS['drives goal'],
+        });
+
+        task.phases.forEach((phase, phaseIndex) => {
+            const phaseId = `phase:${taskIndex}:${phaseIndex}`;
+            registerNode({
+                id: phaseId,
+                label: phase.name,
+                type: 'phase',
+                detail: `Steps: ${phase.tasks.length}`,
+            });
+            registerLink({
+                source: taskId,
+                target: phaseId,
+                relation: 'expands into phase',
+                color: RELATION_COLORS['expands into phase'],
+            });
+
+            phase.tasks.forEach((subtask, subtaskIndex) => {
+                const subtaskId = `subtask:${taskIndex}:${phaseIndex}:${subtaskIndex}`;
+                registerNode({
+                    id: subtaskId,
+                    label: subtask.name,
+                    type: 'subtask',
+                    detail: subtask.outputs.length ? `Outputs: ${subtask.outputs.join(', ')}` : undefined,
+                });
+                registerLink({
+                    source: phaseId,
+                    target: subtaskId,
+                    relation: 'delivers output',
+                    color: RELATION_COLORS['delivers output'],
+                });
+
+                if (subtask.validate) {
+                    const validateId = `validate:${taskIndex}:${phaseIndex}:${subtaskIndex}`;
+                    registerNode({
+                        id: validateId,
+                        label: 'Validate',
+                        type: 'validate',
+                        status: subtask.validate.status,
+                        detail: subtask.validate.checks.length
+                            ? `Checks: ${subtask.validate.checks.join(', ')}`
+                            : undefined,
+                    });
+                    registerLink({
+                        source: subtaskId,
+                        target: validateId,
+                        relation: 'validation step',
+                        color: RELATION_COLORS['validation step'],
+                    });
+                }
+            });
+        });
+    });
+
+    return { nodes, links };
+};
+
+const useContainerSize = (containerRef: React.RefObject<HTMLDivElement>) => {
+    const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+    useEffect(() => {
+        const element = containerRef.current;
+        if (!element) {
+            return;
+        }
+
+        const updateSize = () => {
+            const rect = element.getBoundingClientRect();
+            setDimensions({ width: rect.width, height: rect.height });
+        };
+
+        updateSize();
+
+        if (typeof ResizeObserver !== 'undefined') {
+            const observer = new ResizeObserver(() => updateSize());
+            observer.observe(element);
+            return () => observer.disconnect();
+        }
+
+        window.addEventListener('resize', updateSize);
+        return () => window.removeEventListener('resize', updateSize);
+    }, [containerRef]);
+
+    return dimensions;
+};
+
+interface ScaffoldGraphViewProps {
+    plan: ScaffoldPlan;
+}
+
+export const ScaffoldGraphView: React.FC<ScaffoldGraphViewProps> = ({ plan }) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const graphRef = useRef<ForceGraphMethods<GraphNode, GraphLink> | undefined>(undefined);
+    const { width, height } = useContainerSize(containerRef);
+    const [selectedNode, setSelectedNode] = useState<GraphNode | null>(null);
+    const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null);
+    const [hoveredLink, setHoveredLink] = useState<GraphLink | null>(null);
+
+    const graphData = useMemo(() => buildGraphData(plan), [plan]);
+
+    const nodeIndex = useMemo(() => {
+        const lookup = new Map<string, GraphNode>();
+        graphData.nodes.forEach((node) => {
+            if (node.id !== undefined) {
+                lookup.set(String(node.id), node as GraphNode);
+            }
+        });
+        return lookup;
+    }, [graphData.nodes]);
+
+    useEffect(() => {
+        if (!graphRef.current) {
+            return;
+        }
+        graphRef.current.d3ReheatSimulation();
+        const timeout = window.setTimeout(() => {
+            graphRef.current?.zoomToFit(400, 40);
+        }, 450);
+        return () => window.clearTimeout(timeout);
+    }, [graphData]);
+
+    const renderNode = useCallback(
+        (nodeObject: NodeObject<GraphNodePayload>, ctx: CanvasRenderingContext2D, globalScale: number) => {
+            const node = nodeObject as GraphNode;
+            const meta = NODE_META[node.type] ?? NODE_META.file;
+            const isSelected = selectedNode?.id === node.id;
+            const isHovered = hoveredNode?.id === node.id;
+            const baseRadius = 6 + (node.type === 'project' ? 4 : node.type === 'task' ? 2 : node.type === 'phase' ? 1 : 0);
+            const radius = baseRadius * (isSelected ? 1.4 : isHovered ? 1.2 : 1);
+            const x = node.x ?? 0;
+            const y = node.y ?? 0;
+
+            ctx.beginPath();
+            ctx.arc(x, y, radius, 0, 2 * Math.PI, false);
+            ctx.fillStyle = meta.color;
+            ctx.fill();
+
+            ctx.lineWidth = isSelected ? 2.5 : 1.3;
+            ctx.strokeStyle = isSelected ? '#fef08a' : isHovered ? '#f8fafc' : '#0f172a';
+            ctx.stroke();
+
+            const label = node.label ?? '';
+            if (label) {
+                const fontSize = Math.max(10, 12 / globalScale);
+                ctx.font = `${fontSize}px Inter, system-ui`;
+                ctx.textAlign = 'left';
+                ctx.textBaseline = 'middle';
+                ctx.fillStyle = '#f8fafc';
+                ctx.fillText(label, x + radius + 4, y);
+            }
+        },
+        [hoveredNode, selectedNode]
+    );
+
+    const paintPointer = useCallback((nodeObject: NodeObject<GraphNodePayload>, color: string, ctx: CanvasRenderingContext2D) => {
+        const node = nodeObject as GraphNode;
+        const baseRadius = 6 + (node.type === 'project' ? 4 : node.type === 'task' ? 2 : node.type === 'phase' ? 1 : 0);
+        const x = node.x ?? 0;
+        const y = node.y ?? 0;
+        ctx.beginPath();
+        ctx.arc(x, y, baseRadius, 0, 2 * Math.PI, false);
+        ctx.fillStyle = color;
+        ctx.fill();
+    }, []);
+
+    const handleDownload = useCallback(() => {
+        const canvas = containerRef.current?.querySelector('canvas');
+        if (!canvas) {
+            return;
+        }
+        const dataUrl = canvas.toDataURL('image/png');
+        const link = document.createElement('a');
+        link.href = dataUrl;
+        link.download = `${sanitizeId(plan.project.name)}-scaffold-graph.png`;
+        link.click();
+    }, [plan.project.name]);
+
+    const handleFocus = useCallback(() => {
+        graphRef.current?.zoomToFit(400, 40);
+    }, []);
+
+    const resolveNodeLabel = useCallback(
+        (nodeRef: GraphLink['source']) => {
+            if (!nodeRef) {
+                return '';
+            }
+            if (typeof nodeRef === 'object') {
+                return (nodeRef as GraphNode).label ?? '';
+            }
+            return nodeIndex.get(String(nodeRef))?.label ?? String(nodeRef);
+        },
+        [nodeIndex]
+    );
+
+    return (
+        <div className="relative w-full h-[60vh] rounded-lg border border-border-color bg-background shadow-inner" ref={containerRef}>
+            {width > 0 && height > 0 && (
+                <ForceGraph2D
+                    ref={graphRef as React.MutableRefObject<ForceGraphMethods<any, any> | undefined>}
+                    width={width}
+                    height={height}
+                    backgroundColor="#0b1120"
+                    graphData={graphData}
+                    nodeId="id"
+                    nodeLabel={(node) => {
+                        const typed = node as GraphNode;
+                        const detail = typed.detail ? `\n${typed.detail}` : '';
+                        return `${typed.label ?? ''}${detail}`;
+                    }}
+                    nodeCanvasObject={renderNode}
+                    nodePointerAreaPaint={paintPointer}
+                    linkColor={(link) => (link as GraphLink).color ?? '#64748b'}
+                    linkLabel={(link) => (link as GraphLink).relation}
+                    linkDirectionalArrowLength={4}
+                    linkWidth={() => 1.4}
+                    linkDirectionalParticles={0}
+                    autoPauseRedraw={false}
+                    d3VelocityDecay={0.15}
+                    onNodeHover={(node) => setHoveredNode((node as GraphNode) ?? null)}
+                    onNodeClick={(node) => setSelectedNode(node as GraphNode)}
+                    onBackgroundClick={() => setSelectedNode(null)}
+                    onLinkHover={(link) => setHoveredLink((link as GraphLink) ?? null)}
+                    enableNodeDrag={true}
+                    showPointerCursor={(obj) => Boolean(obj)}
+                />
+            )}
+
+            <div className="pointer-events-none absolute inset-0 flex flex-col justify-between p-3">
+                <div className="flex w-full justify-between items-start gap-3">
+                    <div className="pointer-events-auto max-w-sm rounded-lg border border-border-color bg-background/95 p-4 shadow-lg">
+                        {selectedNode ? (
+                            <>
+                                <div className="flex items-center gap-2">
+                                    <span
+                                        className="inline-block h-3 w-3 rounded-full"
+                                        style={{ backgroundColor: NODE_META[selectedNode.type]?.color ?? '#94a3b8' }}
+                                    ></span>
+                                    <h3 className="text-sm font-semibold text-sky-200">{selectedNode.label}</h3>
+                                </div>
+                                <p className="mt-2 text-xs uppercase tracking-wide text-slate-400">{NODE_META[selectedNode.type]?.label}</p>
+                                {selectedNode.status && (
+                                    <p className="mt-1 text-xs text-emerald-300">Status: {selectedNode.status}</p>
+                                )}
+                                <ul className="mt-2 space-y-1 text-xs text-slate-200">
+                                    {formatDetail(selectedNode.detail).map((line) => (
+                                        <li key={line} className="leading-relaxed">
+                                            {line}
+                                        </li>
+                                    ))}
+                                </ul>
+                                {!selectedNode.detail && (
+                                    <p className="mt-2 text-xs text-slate-400">No additional metadata for this node.</p>
+                                )}
+                            </>
+                        ) : (
+                            <div className="text-xs text-slate-400">
+                                <p className="font-medium text-slate-200">Scaffold graph</p>
+                                <p>Click a node to inspect its metadata. Use the controls on the right to refocus or export the graph.</p>
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="pointer-events-auto flex gap-2">
+                        <button
+                            type="button"
+                            onClick={handleFocus}
+                            className="rounded-md border border-slate-600 bg-slate-800/70 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:bg-slate-700"
+                        >
+                            Re-center
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleDownload}
+                            className="rounded-md border border-sky-500 bg-sky-600/80 px-3 py-1.5 text-xs font-semibold text-slate-50 transition hover:bg-sky-500"
+                        >
+                            Download PNG
+                        </button>
+                    </div>
+                </div>
+
+                <div className="pointer-events-auto flex flex-wrap gap-3">
+                    <div className="rounded-lg border border-border-color bg-background/90 p-3 shadow">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Legend</p>
+                        <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-2 text-xs text-slate-200">
+                            {Object.entries(NODE_META).map(([type, meta]) => (
+                                <div key={type} className="flex items-center gap-2">
+                                    <span className="inline-block h-3 w-3 rounded-full" style={{ backgroundColor: meta.color }}></span>
+                                    <div>
+                                        <p className="font-medium text-slate-100">{meta.label}</p>
+                                        <p className="text-[10px] text-slate-400">{meta.description}</p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+
+                    {hoveredLink && (
+                        <div className="rounded-lg border border-border-color bg-background/90 p-3 shadow">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Relationship</p>
+                            <p className="mt-1 text-xs text-slate-200">{hoveredLink.relation}</p>
+                            <p className="text-[11px] text-slate-400">
+                                {resolveNodeLabel(hoveredLink.source)} → {resolveNodeLabel(hoveredLink.target)}
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ScaffoldGraphView;

--- a/components/views/viewers/ScaffolderViewer.tsx
+++ b/components/views/viewers/ScaffolderViewer.tsx
@@ -1,47 +1,12 @@
 
 
-import React, { useState, useEffect, useRef } from 'react';
-import type { ScaffolderOutput, ScaffoldPlan, ScaffoldTreeItem, ScaffoldTask } from '../../../types';
+import React, { useEffect, useRef, useState } from 'react';
+import type { ScaffolderOutput, ScaffoldTreeItem } from '../../../types';
 import { ChevronRightIcon } from '../../icons/ChevronRightIcon';
 import { enhanceCodeBlocks } from '../../../utils/uiUtils';
+import { ScaffoldGraphView } from './ScaffoldGraphView';
 
 declare var marked: any;
-declare var mermaid: any;
-declare var svgPanZoom: any;
-
-const convertPlanToMermaid = (plan: ScaffoldPlan): string => {
-    let mermaidStr = 'graph TD;\n\n';
-    
-    mermaidStr += `    subgraph "Project Goal: ${plan.project.name}"\n`;
-    mermaidStr += `        direction TB\n`;
-    mermaidStr += `        g1(("${plan.project.name}"));\n`; // Corrected: circle shape
-    mermaidStr += `    end\n\n`;
-
-    plan.tasks.forEach((task, taskIndex) => {
-        const goalId = `g${taskIndex + 1}`;
-        mermaidStr += `    ${goalId}{{"${task.goal}"}};\n`;
-        
-        task.phases.forEach((phase, phaseIndex) => {
-            const phaseId = `p${taskIndex}_${phaseIndex}`;
-            mermaidStr += `    ${phaseId}["${phase.name}"];\n`;
-            mermaidStr += `    ${goalId} --> ${phaseId};\n`;
-            
-            phase.tasks.forEach((subtask, subtaskIndex) => {
-                const subtaskId = `t${taskIndex}_${phaseIndex}_${subtaskIndex}`;
-                const validateId = `v${taskIndex}_${phaseIndex}_${subtaskIndex}`;
-                mermaidStr += `    ${subtaskId}(["${subtask.name}"]);\n`; // Corrected: stadium shape
-                mermaidStr += `    ${validateId}{"Validate"};\n`; // Corrected: rhombus shape
-                mermaidStr += `    ${phaseId} --> ${subtaskId};\n`;
-                mermaidStr += `    ${subtaskId} -.-> ${validateId};\n`;
-                mermaidStr += `    class ${validateId} validate-pass;\n`;
-            });
-        });
-    });
-
-    mermaidStr += '\nclassDef validate-pass fill:#22c55e,stroke:#fff,stroke-width:2px,color:#000,font-weight:bold;\n';
-    
-    return mermaidStr;
-};
 
 
 interface FileTreeNodeProps {
@@ -113,8 +78,6 @@ const buildFileTree = (files: ScaffoldTreeItem[], onFileClick: (file: ScaffoldTr
 export const ScaffolderViewer: React.FC<{ output: ScaffolderOutput }> = ({ output }) => {
     const [activeTab, setActiveTab] = useState<'tree' | 'graph' | 'plan' | 'script'>('tree');
     const [selectedFile, setSelectedFile] = useState<ScaffoldTreeItem | null>(null);
-    const mermaidContainerRef = useRef<HTMLDivElement>(null);
-    const panZoomInstanceRef = useRef<any>(null);
     const promptDisplayRef = useRef<HTMLDivElement>(null);
     const scriptDisplayRef = useRef<HTMLDivElement>(null);
 
@@ -141,29 +104,6 @@ export const ScaffolderViewer: React.FC<{ output: ScaffolderOutput }> = ({ outpu
             enhanceCodeBlocks(scriptDisplayRef.current);
         }
     }, [activeTab, output.scaffoldScript, output.scaffoldPlanJson.project.language]);
-
-    useEffect(() => {
-        if (panZoomInstanceRef.current) {
-            panZoomInstanceRef.current.destroy(); panZoomInstanceRef.current = null;
-        }
-        if (activeTab === 'graph' && mermaidContainerRef.current && typeof mermaid !== 'undefined') {
-            try {
-                const mermaidCode = convertPlanToMermaid(output.scaffoldPlanJson);
-                const uniqueId = `mermaid-scaffold-${Date.now()}`;
-                mermaid.render(uniqueId, mermaidCode, (svgCode) => {
-                    if (mermaidContainerRef.current) {
-                        mermaidContainerRef.current.innerHTML = svgCode;
-                        const svgElement = mermaidContainerRef.current.querySelector('svg');
-                        if (svgElement && typeof svgPanZoom !== 'undefined') {
-                            svgElement.style.width = '100%'; svgElement.style.height = '100%';
-                            panZoomInstanceRef.current = svgPanZoom(svgElement, { panEnabled: true, controlIconsEnabled: true, zoomEnabled: true, dblClickZoomEnabled: true, mouseWheelZoomEnabled: true, preventMouseEventsDefault: true, zoomScaleSensitivity: 0.2, minZoom: 0.1, maxZoom: 10, fit: true, center: true, contain: true });
-                            setTimeout(() => { panZoomInstanceRef.current.resize(); panZoomInstanceRef.current.center(); }, 100);
-                        }
-                    }
-                });
-            } catch (e) { console.error("Mermaid.js rendering failed:", e); if (mermaidContainerRef.current) { mermaidContainerRef.current.innerHTML = `<p class="text-red-400">Error rendering diagram. See console.</p>`; } }
-        } else if (mermaidContainerRef.current) { mermaidContainerRef.current.innerHTML = ''; }
-    }, [activeTab, output.scaffoldPlanJson]);
 
     const TABS = [ { id: 'tree', label: 'File Tree & Prompts' }, { id: 'graph', label: 'Scaffold Graph' }, { id: 'plan', label: 'Plan (JSON)' }, { id: 'script', label: 'Script' } ];
 
@@ -198,7 +138,11 @@ export const ScaffolderViewer: React.FC<{ output: ScaffolderOutput }> = ({ outpu
                             </div>
                         </div>
                     )}
-                    {activeTab === 'graph' && (<div className="p-4 bg-background rounded-lg min-h-[60vh] overflow-hidden shadow-inner flex justify-center items-center"><div ref={mermaidContainerRef} className="w-full h-full cursor-move"></div></div>)}
+                    {activeTab === 'graph' && (
+                        <div className="p-4 bg-background rounded-lg min-h-[60vh] overflow-hidden shadow-inner">
+                            <ScaffoldGraphView plan={output.scaffoldPlanJson} />
+                        </div>
+                    )}
                     {activeTab === 'plan' && (<div className="p-4 bg-background rounded-lg max-h-[60vh] overflow-y-auto shadow-inner"><pre className="text-xs whitespace-pre-wrap text-slate-300"><code>{JSON.stringify(output.scaffoldPlanJson, null, 2)}</code></pre></div>)}
                     {activeTab === 'script' && (<div ref={scriptDisplayRef} className="p-4 bg-background rounded-lg max-h-[60vh] overflow-y-auto shadow-inner prose prose-sm prose-invert max-w-none"></div>)}
                 </div>

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,17 @@
 
 
-import type { ProgressUpdate, ReasoningSettings, ScaffolderSettings, RequestSplitterSettings, PromptEnhancerSettings, AgentDesignerSettings, ChatSettings } from './types';
+import type {
+  ProgressUpdate,
+  ReasoningSettings,
+  ScaffolderSettings,
+  RequestSplitterSettings,
+  PromptEnhancerSettings,
+  AgentDesignerSettings,
+  ChatSettings,
+  AIProviderSettings,
+  AIProviderId,
+  EmbeddingProviderId,
+} from './types';
 
 // Import all summary prompts from the new modular structure
 import * as summaryPrompts from './prompts/summaries';
@@ -19,9 +30,22 @@ import { REQUEST_SPLITTER_PLANNING_PROMPT_TEMPLATE, REQUEST_SPLITTER_GENERATION_
 import { PROMPT_ENHANCER_PROMPT_TEMPLATE } from './prompts/promptEnhancer/index';
 // FIX: Corrected import path for agent designer template
 import { AGENT_DESIGNER_PROMPT_TEMPLATE } from './prompts/agentDesigner/index';
+export const DEFAULT_PROVIDER_MODELS: Record<AIProviderId, string> = {
+  openai: 'gpt-4o-mini',
+  openrouter: 'openrouter/auto',
+  xai: 'grok-beta',
+  deepseek: 'deepseek-chat',
+  anthropic: 'claude-3-5-sonnet-latest',
+  ollama: 'llama3.1:8b',
+};
 
-
-export const GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
+export const DEFAULT_EMBEDDING_MODELS: Record<EmbeddingProviderId, string> = {
+  openai: 'text-embedding-3-small',
+  openrouter: 'text-embedding-3-small',
+  deepseek: 'deepseek-embedding',
+  ollama: 'nomic-embed-text',
+  custom: '',
+};
 
 // Approximate token estimation: 1 token ~ 4 characters.
 // Target chunk size for LLM processing. Drastically increased to maximize model's context window.
@@ -103,6 +127,25 @@ export const INITIAL_AGENT_DESIGNER_SETTINGS: AgentDesignerSettings = {
 
 export const INITIAL_CHAT_SETTINGS: ChatSettings = {
     systemInstruction: 'You are a helpful and friendly AI assistant. Answer the user\'s questions clearly and concisely.',
+    vectorStore: {
+        enabled: false,
+        url: '',
+        apiKey: '',
+        collection: '',
+        topK: 5,
+        embedding: {
+            provider: 'openai',
+            model: DEFAULT_EMBEDDING_MODELS.openai,
+            apiKey: '',
+            baseUrl: '',
+        },
+    },
+};
+
+export const INITIAL_AI_PROVIDER_SETTINGS: AIProviderSettings = {
+    selectedProvider: 'openai',
+    selectedModel: DEFAULT_PROVIDER_MODELS.openai,
+    apiKeys: {},
 };
 
 // --- Prompt Collections (Re-constructed from imports) ---

--- a/constants/uiConstants.ts
+++ b/constants/uiConstants.ts
@@ -12,7 +12,9 @@ export const TABS = [
     { id: 'promptEnhancer', label: 'Prompt Enhancer' },
     { id: 'agentDesigner', label: 'Agent Designer' },
     { id: 'chat', label: 'LLM Chat' },
-];
+] as const;
+
+export const MODE_IDS: Mode[] = TABS.map(tab => tab.id as Mode);
 
 export const DESCRIPTION_TEXT: Record<Mode, string> = {
     technical: "Upload files, or paste text below, to get a concise summary and key highlights.",

--- a/hooks/useChatSubmission.ts
+++ b/hooks/useChatSubmission.ts
@@ -1,0 +1,130 @@
+import { useCallback } from 'react';
+import type { FormEvent } from 'react';
+import type { Mode, ChatMessage, ChatSettings, AIProviderSettings } from '../types';
+import type { WorkspaceState } from './useWorkspaceState';
+import type { ProviderInfo } from '../services/providerRegistry';
+import type { SetModeValue } from './useMainFormProps';
+import { sendChatMessage } from '../services/geminiService';
+import { fileToGenerativePart } from '../utils/fileUtils';
+
+interface UseChatSubmissionParams {
+  activeMode: Mode;
+  aiProviderSettings: AIProviderSettings;
+  activeProviderInfo?: ProviderInfo;
+  chatSettings: ChatSettings;
+  canSubmit: boolean;
+  chatInput: string;
+  chatFiles: File[] | null;
+  getStateForMode: (mode: Mode) => WorkspaceState;
+  setModeValue: SetModeValue;
+}
+
+export const useChatSubmission = ({
+  activeMode,
+  aiProviderSettings,
+  activeProviderInfo,
+  chatSettings,
+  canSubmit,
+  chatInput,
+  chatFiles,
+  getStateForMode,
+  setModeValue,
+}: UseChatSubmissionParams) => {
+  return useCallback(
+    async (event?: FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+      if (!canSubmit) return;
+
+      const modeAtSubmit = activeMode;
+      if (activeProviderInfo?.requiresApiKey) {
+        const apiKeyForProvider = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
+        if (!apiKeyForProvider || apiKeyForProvider.trim() === '') {
+          setModeValue(
+            'error',
+            {
+              message: `${activeProviderInfo.label} requires an API key. Please add it in settings before starting a chat.`,
+            },
+            modeAtSubmit,
+          );
+          return;
+        }
+      }
+
+      const historyBeforeMessage = [...getStateForMode(modeAtSubmit).chatHistory];
+      const trimmedInput = chatInput.trim();
+
+      const fileParts = chatFiles ? await Promise.all(chatFiles.map(fileToGenerativePart)) : [];
+      const textParts = trimmedInput ? [{ text: trimmedInput }] : [];
+      const userMessageParts = [...fileParts, ...textParts];
+
+      if (userMessageParts.length === 0) {
+        return;
+      }
+
+      const userMessage: ChatMessage = { role: 'user', parts: userMessageParts };
+      const placeholder: ChatMessage = { role: 'model', parts: [{ text: '' }], thinking: [] };
+
+      setModeValue('chatHistory', prev => [...prev, userMessage, placeholder], modeAtSubmit);
+      setModeValue('chatInput', '', modeAtSubmit);
+      setModeValue('chatFiles', null, modeAtSubmit);
+      setModeValue('isStreamingResponse', true, modeAtSubmit);
+      setModeValue('error', null, modeAtSubmit);
+
+      try {
+        const response = await sendChatMessage({
+          history: historyBeforeMessage,
+          userMessage: userMessageParts,
+          systemInstruction: chatSettings.systemInstruction,
+          vectorStoreSettings: chatSettings.vectorStore,
+        });
+
+        setModeValue(
+          'chatHistory',
+          prev => {
+            if (prev.length === 0) return prev;
+            const updated = [...prev];
+            const lastIndex = updated.length - 1;
+            const lastMessage = updated[lastIndex];
+            if (lastMessage && lastMessage.role === 'model') {
+              const thinkingSegments = response.thinking.length > 0 ? [...response.thinking] : undefined;
+              const finalText = response.text;
+              const firstPart = lastMessage.parts[0];
+
+              if (firstPart && 'text' in firstPart) {
+                firstPart.text = finalText;
+                lastMessage.thinking = thinkingSegments;
+              } else {
+                updated[lastIndex] = { role: 'model', parts: [{ text: finalText }], thinking: thinkingSegments };
+              }
+            }
+            return updated;
+          },
+          modeAtSubmit,
+        );
+      } catch (err) {
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          setModeValue('chatHistory', prev => (prev.length > 0 ? prev.slice(0, prev.length - 1) : prev), modeAtSubmit);
+          return;
+        }
+        console.error('Chat error:', err);
+        const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred.';
+        setModeValue('error', { message: `Chat failed: ${errorMessage}` }, modeAtSubmit);
+        setModeValue('chatHistory', prev => (prev.length > 0 ? prev.slice(0, prev.length - 1) : prev), modeAtSubmit);
+      } finally {
+        setModeValue('isStreamingResponse', false, modeAtSubmit);
+      }
+    },
+    [
+      activeMode,
+      activeProviderInfo,
+      aiProviderSettings,
+      chatSettings.systemInstruction,
+      chatSettings.vectorStore,
+      canSubmit,
+      chatInput,
+      chatFiles,
+      getStateForMode,
+      setModeValue,
+    ],
+  );
+};

--- a/hooks/useLayoutPreferences.ts
+++ b/hooks/useLayoutPreferences.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const SIDEBAR_STATE_STORAGE_KEY = 'ai_content_suite_sidebar_state';
+const LAYOUT_WIDTH_STORAGE_KEY = 'ai_content_suite_layout_width';
+const MIN_CONTENT_WIDTH = 640;
+const MAX_CONTENT_WIDTH = 1440;
+const DEFAULT_LAYOUT_PERCENT = 70;
+
+export const useLayoutPreferences = () => {
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+    const saved = localStorage.getItem(SIDEBAR_STATE_STORAGE_KEY);
+    return saved === 'collapsed';
+  });
+
+  const [contentWidthPercent, setContentWidthPercent] = useState<number>(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_LAYOUT_PERCENT;
+    }
+    const saved = Number(localStorage.getItem(LAYOUT_WIDTH_STORAGE_KEY));
+    return Number.isFinite(saved) && saved >= 0 && saved <= 100 ? saved : DEFAULT_LAYOUT_PERCENT;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    localStorage.setItem(SIDEBAR_STATE_STORAGE_KEY, isSidebarCollapsed ? 'collapsed' : 'expanded');
+  }, [isSidebarCollapsed]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    localStorage.setItem(LAYOUT_WIDTH_STORAGE_KEY, String(contentWidthPercent));
+  }, [contentWidthPercent]);
+
+  const toggleSidebar = useCallback(() => {
+    setIsSidebarCollapsed(prev => !prev);
+  }, []);
+
+  const contentWidthPixels = useMemo(
+    () => MIN_CONTENT_WIDTH + ((MAX_CONTENT_WIDTH - MIN_CONTENT_WIDTH) * contentWidthPercent) / 100,
+    [contentWidthPercent],
+  );
+
+  const appliedContentWidth = useMemo(
+    () => (contentWidthPercent >= 100 ? '100%' : `${Math.round(contentWidthPixels)}px`),
+    [contentWidthPercent, contentWidthPixels],
+  );
+
+  const contentWidthLabel = useMemo(
+    () => (contentWidthPercent >= 100 ? 'Full width' : `${Math.round(contentWidthPixels)}px`),
+    [contentWidthPercent, contentWidthPixels],
+  );
+
+  return {
+    isSidebarCollapsed,
+    toggleSidebar,
+    contentWidthPercent,
+    setContentWidthPercent,
+    appliedContentWidth,
+    contentWidthLabel,
+  } as const;
+};

--- a/hooks/useMainFormProps.ts
+++ b/hooks/useMainFormProps.ts
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import type { SetStateAction } from 'react';
+import type { Mode } from '../types';
+import type { MainFormProps } from '../components/layouts/MainForm';
+import type { WorkspaceState } from './useWorkspaceState';
+
+export type SetModeValue = <K extends keyof WorkspaceState>(
+  key: K,
+  value: SetStateAction<WorkspaceState[K]>,
+  mode?: Mode,
+) => void;
+
+interface UseMainFormPropsParams {
+  activeMode: Mode;
+  state: WorkspaceState;
+  setModeValue: SetModeValue;
+  onFileSelect: (files: File[]) => void;
+  onSummaryTextChange: (text: string) => void;
+}
+
+export const useMainFormProps = ({
+  activeMode,
+  state,
+  setModeValue,
+  onFileSelect,
+  onSummaryTextChange,
+}: UseMainFormPropsParams): MainFormProps => {
+  return useMemo(
+    () => ({
+      activeMode,
+      currentFiles: state.currentFiles,
+      summaryFormat: state.summaryFormat,
+      onSummaryFormatChange: value => setModeValue('summaryFormat', value),
+      summarySearchTerm: state.summarySearchTerm,
+      onSummarySearchTermChange: value => setModeValue('summarySearchTerm', value),
+      summaryTextInput: state.summaryTextInput,
+      onSummaryTextChange,
+      useHierarchical: state.useHierarchical,
+      onUseHierarchicalChange: value => setModeValue('useHierarchical', value),
+      styleTarget: state.styleTarget,
+      onStyleTargetChange: value => setModeValue('styleTarget', value),
+      rewriteStyle: state.rewriteStyle,
+      onRewriteStyleChange: value => setModeValue('rewriteStyle', value),
+      rewriteInstructions: state.rewriteInstructions,
+      onRewriteInstructionsChange: value => setModeValue('rewriteInstructions', value),
+      rewriteLength: state.rewriteLength,
+      onRewriteLengthChange: value => setModeValue('rewriteLength', value),
+      reasoningPrompt: state.reasoningPrompt,
+      onReasoningPromptChange: value => setModeValue('reasoningPrompt', value),
+      reasoningSettings: state.reasoningSettings,
+      onReasoningSettingsChange: value => setModeValue('reasoningSettings', value),
+      scaffolderPrompt: state.scaffolderPrompt,
+      onScaffolderPromptChange: value => setModeValue('scaffolderPrompt', value),
+      scaffolderSettings: state.scaffolderSettings,
+      onScaffolderSettingsChange: value => setModeValue('scaffolderSettings', value),
+      requestSplitterSpec: state.requestSplitterSpec,
+      onRequestSplitterSpecChange: value => setModeValue('requestSplitterSpec', value),
+      requestSplitterSettings: state.requestSplitterSettings,
+      onRequestSplitterSettingsChange: value => setModeValue('requestSplitterSettings', value),
+      promptEnhancerSettings: state.promptEnhancerSettings,
+      onPromptEnhancerSettingsChange: value => setModeValue('promptEnhancerSettings', value),
+      agentDesignerSettings: state.agentDesignerSettings,
+      onAgentDesignerSettingsChange: value => setModeValue('agentDesignerSettings', value),
+      onFileSelect,
+    }),
+    [activeMode, onFileSelect, onSummaryTextChange, setModeValue, state],
+  );
+};

--- a/hooks/usePersistentChatSettings.ts
+++ b/hooks/usePersistentChatSettings.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import type { ChatSettings } from '../types';
+import { INITIAL_CHAT_SETTINGS } from '../constants';
+
+const CHAT_SETTINGS_STORAGE_KEY = 'ai_content_suite_chat_settings';
+
+const getInitialChatSettings = (): ChatSettings => {
+  if (typeof window === 'undefined') {
+    return INITIAL_CHAT_SETTINGS;
+  }
+
+  try {
+    const saved = localStorage.getItem(CHAT_SETTINGS_STORAGE_KEY);
+    if (!saved) {
+      return INITIAL_CHAT_SETTINGS;
+    }
+
+    const parsed = JSON.parse(saved);
+    if (!parsed || typeof parsed !== 'object') {
+      return INITIAL_CHAT_SETTINGS;
+    }
+
+    const defaults = INITIAL_CHAT_SETTINGS.vectorStore;
+    const parsedVectorStore =
+      parsed.vectorStore && typeof parsed.vectorStore === 'object' ? parsed.vectorStore : {};
+
+    const mergedVectorStore = defaults
+      ? {
+          ...defaults,
+          ...parsedVectorStore,
+          embedding: {
+            ...defaults.embedding,
+            ...(parsedVectorStore.embedding ?? {}),
+          },
+        }
+      : parsedVectorStore;
+
+    return {
+      ...INITIAL_CHAT_SETTINGS,
+      ...parsed,
+      vectorStore: mergedVectorStore,
+    } as ChatSettings;
+  } catch (error) {
+    console.error('Failed to load chat settings from local storage:', error);
+    return INITIAL_CHAT_SETTINGS;
+  }
+};
+
+export const usePersistentChatSettings = () => {
+  const [chatSettings, setChatSettings] = useState<ChatSettings>(getInitialChatSettings);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      localStorage.setItem(CHAT_SETTINGS_STORAGE_KEY, JSON.stringify(chatSettings));
+    } catch (error) {
+      console.error('Failed to save chat settings to local storage:', error);
+    }
+  }, [chatSettings]);
+
+  return { chatSettings, setChatSettings } as const;
+};

--- a/hooks/usePersistentProviderSettings.ts
+++ b/hooks/usePersistentProviderSettings.ts
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { AIProviderSettings } from '../types';
+import { DEFAULT_PROVIDER_MODELS, INITIAL_AI_PROVIDER_SETTINGS } from '../constants';
+import { AI_PROVIDERS, getProviderLabel } from '../services/providerRegistry';
+
+const PROVIDER_SETTINGS_STORAGE_KEY = 'ai_content_suite_provider_settings';
+
+const getInitialProviderSettings = (): AIProviderSettings => {
+  if (typeof window === 'undefined') {
+    return INITIAL_AI_PROVIDER_SETTINGS;
+  }
+
+  try {
+    const saved = localStorage.getItem(PROVIDER_SETTINGS_STORAGE_KEY);
+    if (!saved) {
+      return INITIAL_AI_PROVIDER_SETTINGS;
+    }
+
+    const parsed = JSON.parse(saved) as Partial<AIProviderSettings> | null;
+    if (!parsed || typeof parsed !== 'object') {
+      return INITIAL_AI_PROVIDER_SETTINGS;
+    }
+
+    const availableProviders = new Set(AI_PROVIDERS.map(provider => provider.id));
+    const selectedProvider = availableProviders.has(parsed.selectedProvider)
+      ? parsed.selectedProvider!
+      : INITIAL_AI_PROVIDER_SETTINGS.selectedProvider;
+
+    const fallbackModel =
+      DEFAULT_PROVIDER_MODELS[selectedProvider] ??
+      DEFAULT_PROVIDER_MODELS[INITIAL_AI_PROVIDER_SETTINGS.selectedProvider];
+
+    const selectedModel =
+      typeof parsed.selectedModel === 'string' && parsed.selectedModel.trim().length > 0
+        ? parsed.selectedModel
+        : fallbackModel;
+
+    const apiKeys =
+      parsed.apiKeys && typeof parsed.apiKeys === 'object' && parsed.apiKeys !== null ? parsed.apiKeys : {};
+
+    return {
+      selectedProvider,
+      selectedModel,
+      apiKeys,
+    };
+  } catch (error) {
+    console.error('Failed to load provider settings from local storage:', error);
+    return INITIAL_AI_PROVIDER_SETTINGS;
+  }
+};
+
+export const usePersistentProviderSettings = () => {
+  const [providerSettings, setProviderSettings] = useState<AIProviderSettings>(getInitialProviderSettings);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      localStorage.setItem(PROVIDER_SETTINGS_STORAGE_KEY, JSON.stringify(providerSettings));
+    } catch (error) {
+      console.error('Failed to save provider settings to local storage:', error);
+    }
+  }, [providerSettings]);
+
+  const activeProviderInfo = useMemo(
+    () => AI_PROVIDERS.find(provider => provider.id === providerSettings.selectedProvider),
+    [providerSettings.selectedProvider],
+  );
+
+  const activeProviderLabel = useMemo(
+    () => getProviderLabel(providerSettings.selectedProvider),
+    [providerSettings.selectedProvider],
+  );
+
+  const activeModelName = useMemo(() => {
+    const trimmed = providerSettings.selectedModel?.trim();
+    if (trimmed && trimmed.length > 0) {
+      return trimmed;
+    }
+    return DEFAULT_PROVIDER_MODELS[providerSettings.selectedProvider] ?? '';
+  }, [providerSettings]);
+
+  const isApiKeyConfigured = useMemo(() => {
+    const key = providerSettings.apiKeys?.[providerSettings.selectedProvider];
+    return typeof key === 'string' && key.trim().length > 0;
+  }, [providerSettings]);
+
+  const providerStatusText = useMemo(() => {
+    if (!activeProviderInfo) return 'Provider status unavailable';
+    if (activeProviderInfo.requiresApiKey) {
+      return isApiKeyConfigured ? 'API key saved' : 'API key required';
+    }
+    return 'API key optional';
+  }, [activeProviderInfo, isApiKeyConfigured]);
+
+  const providerStatusTone = useMemo(() => {
+    if (!activeProviderInfo) return 'text-destructive';
+    if (activeProviderInfo.requiresApiKey) {
+      return isApiKeyConfigured ? 'text-emerald-400' : 'text-destructive';
+    }
+    return 'text-text-secondary';
+  }, [activeProviderInfo, isApiKeyConfigured]);
+
+  const providerSummaryText = useMemo(
+    () => (activeModelName ? `${activeProviderLabel} • ${activeModelName}` : activeProviderLabel),
+    [activeProviderLabel, activeModelName],
+  );
+
+  return {
+    providerSettings,
+    setProviderSettings,
+    activeProviderInfo,
+    activeProviderLabel,
+    activeModelName,
+    providerStatusText,
+    providerStatusTone,
+    providerSummaryText,
+  } as const;
+};

--- a/hooks/useSavedPrompts.ts
+++ b/hooks/useSavedPrompts.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import type { SavedPrompt } from '../types';
+
+const SAVED_PROMPTS_STORAGE_KEY = 'ai_content_suite_saved_prompts';
+
+const getInitialSavedPrompts = (): SavedPrompt[] => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const saved = localStorage.getItem(SAVED_PROMPTS_STORAGE_KEY);
+    if (!saved) {
+      return [];
+    }
+    const parsed = JSON.parse(saved);
+    return Array.isArray(parsed) ? (parsed as SavedPrompt[]) : [];
+  } catch (error) {
+    console.error('Failed to load saved prompts from local storage:', error);
+    return [];
+  }
+};
+
+export const useSavedPrompts = () => {
+  const [savedPrompts, setSavedPrompts] = useState<SavedPrompt[]>(getInitialSavedPrompts);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      localStorage.setItem(SAVED_PROMPTS_STORAGE_KEY, JSON.stringify(savedPrompts));
+    } catch (error) {
+      console.error('Failed to save prompts to local storage:', error);
+    }
+  }, [savedPrompts]);
+
+  return { savedPrompts, setSavedPrompts } as const;
+};

--- a/hooks/useWorkspaceState.ts
+++ b/hooks/useWorkspaceState.ts
@@ -1,0 +1,165 @@
+import { useCallback, useMemo, useState } from 'react';
+import type {
+  AgentDesignerSettings,
+  AppState,
+  ChatMessage,
+  Mode,
+  ProcessedOutput,
+  ProcessingError,
+  ProgressUpdate,
+  PromptEnhancerSettings,
+  ReasoningSettings,
+  RequestSplitterSettings,
+  RewriteLength,
+  ScaffolderSettings,
+  SummaryFormat,
+} from '../types';
+import {
+  INITIAL_AGENT_DESIGNER_SETTINGS,
+  INITIAL_PROGRESS,
+  INITIAL_PROMPT_ENHANCER_SETTINGS,
+  INITIAL_REASONING_SETTINGS,
+  INITIAL_REQUEST_SPLITTER_SETTINGS,
+  INITIAL_SCAFFOLDER_SETTINGS,
+} from '../constants';
+import { MODE_IDS } from '../constants/uiConstants';
+import { deepClone } from '../utils/deepClone';
+
+export interface WorkspaceState {
+  currentFiles: File[] | null;
+  appState: AppState;
+  progress: ProgressUpdate;
+  processedData: ProcessedOutput | null;
+  error: ProcessingError | null;
+  nextStepSuggestions: string[] | null;
+  suggestionsLoading: boolean;
+  styleTarget: string;
+  rewriteStyle: string;
+  rewriteInstructions: string;
+  rewriteLength: RewriteLength;
+  useHierarchical: boolean;
+  summaryFormat: SummaryFormat;
+  summarySearchTerm: string;
+  summaryTextInput: string;
+  reasoningPrompt: string;
+  reasoningSettings: ReasoningSettings;
+  scaffolderPrompt: string;
+  scaffolderSettings: ScaffolderSettings;
+  requestSplitterSpec: string;
+  requestSplitterSettings: RequestSplitterSettings;
+  promptEnhancerSettings: PromptEnhancerSettings;
+  agentDesignerSettings: AgentDesignerSettings;
+  chatHistory: ChatMessage[];
+  isStreamingResponse: boolean;
+  chatInput: string;
+  chatFiles: File[] | null;
+}
+
+type SetStateAction<T> = T | ((prev: T) => T);
+
+type WorkspaceUpdate = Partial<WorkspaceState> | ((prev: WorkspaceState) => WorkspaceState);
+
+type WorkspaceMap = Record<Mode, WorkspaceState>;
+
+const createInitialWorkspaceState = (): WorkspaceState => ({
+  currentFiles: null,
+  appState: 'idle',
+  progress: deepClone(INITIAL_PROGRESS),
+  processedData: null,
+  error: null,
+  nextStepSuggestions: null,
+  suggestionsLoading: false,
+  styleTarget: '',
+  rewriteStyle: '',
+  rewriteInstructions: '',
+  rewriteLength: 'medium',
+  useHierarchical: false,
+  summaryFormat: 'default',
+  summarySearchTerm: '',
+  summaryTextInput: '',
+  reasoningPrompt: '',
+  reasoningSettings: deepClone(INITIAL_REASONING_SETTINGS),
+  scaffolderPrompt: '',
+  scaffolderSettings: deepClone(INITIAL_SCAFFOLDER_SETTINGS),
+  requestSplitterSpec: '',
+  requestSplitterSettings: deepClone(INITIAL_REQUEST_SPLITTER_SETTINGS),
+  promptEnhancerSettings: deepClone(INITIAL_PROMPT_ENHANCER_SETTINGS),
+  agentDesignerSettings: deepClone(INITIAL_AGENT_DESIGNER_SETTINGS),
+  chatHistory: [],
+  isStreamingResponse: false,
+  chatInput: '',
+  chatFiles: null,
+});
+
+const createInitialWorkspaceMap = (): WorkspaceMap => {
+  return MODE_IDS.reduce((acc, mode) => {
+    acc[mode] = createInitialWorkspaceState();
+    return acc;
+  }, {} as WorkspaceMap);
+};
+
+export const useWorkspaceState = (activeMode: Mode) => {
+  const [stateByMode, setStateByMode] = useState<WorkspaceMap>(() => createInitialWorkspaceMap());
+
+  const setStateForMode = useCallback(
+    (mode: Mode, updater: WorkspaceUpdate): void => {
+      setStateByMode(prev => {
+        const previous = prev[mode];
+        const updated = typeof updater === 'function'
+          ? (updater as (prevState: WorkspaceState) => WorkspaceState)(previous)
+          : { ...previous, ...updater };
+
+        if (previous === updated) {
+          return prev;
+        }
+
+        return { ...prev, [mode]: { ...updated } };
+      });
+    },
+    [],
+  );
+
+  const setValue = useCallback(
+    <K extends keyof WorkspaceState>(key: K, value: SetStateAction<WorkspaceState[K]>, mode: Mode = activeMode) => {
+      setStateForMode(mode, prevState => {
+        const nextValue = typeof value === 'function'
+          ? (value as (prev: WorkspaceState[K]) => WorkspaceState[K])(prevState[key])
+          : value;
+
+        if (Object.is(prevState[key], nextValue)) {
+          return prevState;
+        }
+
+        return { ...prevState, [key]: nextValue };
+      });
+    },
+    [activeMode, setStateForMode],
+  );
+
+  const mergeState = useCallback(
+    (update: Partial<WorkspaceState>, mode: Mode = activeMode) => {
+      setStateForMode(mode, prev => ({ ...prev, ...update }));
+    },
+    [activeMode, setStateForMode],
+  );
+
+  const resetMode = useCallback(
+    (mode: Mode = activeMode) => {
+      setStateForMode(mode, createInitialWorkspaceState());
+    },
+    [activeMode, setStateForMode],
+  );
+
+  const getStateForMode = useCallback((mode: Mode) => stateByMode[mode], [stateByMode]);
+
+  const state = useMemo(() => stateByMode[activeMode], [stateByMode, activeMode]);
+
+  return {
+    state,
+    setValue,
+    mergeState,
+    resetMode,
+    getStateForMode,
+    setStateForMode,
+  };
+};

--- a/index.html
+++ b/index.html
@@ -182,7 +182,6 @@
     "react": "https://esm.sh/react@^19.1.0",
     "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
     "react/": "https://esm.sh/react@^19.1.0/",
-    "@google/genai": "https://esm.sh/@google/genai@^1.3.0",
     "pdfjs-dist": "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.4.168/build/pdf.min.mjs",
     "tesseract.js": "https://esm.sh/tesseract.js@5.1.0"
   }

--- a/index.tsx
+++ b/index.tsx
@@ -28,11 +28,11 @@ if (typeof process === 'undefined') {
   window.process = { env: {} };
 }
 if (!process.env.API_KEY) {
-  // IMPORTANT: Replace this with your actual API key or use environment variables.
+  // IMPORTANT: Replace this with your default API key or manage credentials at runtime via the AI Settings dialog.
   // For safety, it's best to manage API keys outside of version control.
   // This is only a placeholder for the application to run in a sandboxed environment.
-  // process.env.API_KEY = "YOUR_GEMINI_API_KEY"; 
-  console.warn("API_KEY environment variable is not set. Gemini API calls will fail.");
+  // process.env.API_KEY = "YOUR_DEFAULT_AI_API_KEY";
+  console.warn("API_KEY environment variable is not set. Configure provider keys from the AI Settings dialog before using AI features.");
 }
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "AI Content Suite",
-  "description": "An AI-powered text analysis and content generation tool. It can summarize technical transcripts, extract writing styles, rewrite documents, decompose large requests, enhance prompts for agents, and more using the Gemini API.",
+  "description": "An AI-powered text analysis and content generation tool. It can summarize technical transcripts, extract writing styles, rewrite documents, decompose large requests, enhance prompts for agents, and more using configurable AI providers (OpenAI, OpenRouter, xAI, DeepSeek, Anthropic, and Ollama).",
   "requestFramePermissions": [],
   "prompt": ""
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2999 @@
+{
+  "name": "ai-content-suite",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-content-suite",
+      "version": "0.0.0",
+      "dependencies": {
+        "pdfjs-dist": "4.4.168",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
+        "react-force-graph-2d": "^1.29.0",
+        "tesseract.js": "5.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.14.0",
+        "@vitejs/plugin-react": "^5.0.0",
+        "typescript": "~5.8.2",
+        "vite": "^6.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz",
+      "integrity": "sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.0.tgz",
+      "integrity": "sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.0.tgz",
+      "integrity": "sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.0.tgz",
+      "integrity": "sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.0.tgz",
+      "integrity": "sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.0.tgz",
+      "integrity": "sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.0.tgz",
+      "integrity": "sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.0.tgz",
+      "integrity": "sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.0.tgz",
+      "integrity": "sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.0.tgz",
+      "integrity": "sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.0.tgz",
+      "integrity": "sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.0.tgz",
+      "integrity": "sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.0.tgz",
+      "integrity": "sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.0.tgz",
+      "integrity": "sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.0.tgz",
+      "integrity": "sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.0.tgz",
+      "integrity": "sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.0.tgz",
+      "integrity": "sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.0.tgz",
+      "integrity": "sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.0.tgz",
+      "integrity": "sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.0.tgz",
+      "integrity": "sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.0.tgz",
+      "integrity": "sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.0.tgz",
+      "integrity": "sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.0.tgz",
+      "integrity": "sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.0.3.tgz",
+      "integrity": "sha512-PFVHhosKkofGH0Yzrw1BipSedTH68BFF8ZWy1kfUpCtJcouXXY0+racG8sExw7hw0HoX36813ga5o3LTWZ4FUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.35",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
+      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+      "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.0",
+        "nan": "^2.17.0",
+        "simple-get": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.222",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
+      "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.0.tgz",
+      "integrity": "sha512-aTnihCmiMA0ItLJLCbrQYS9mzriopW24goFPgUnKAAmAlPogTSmFWqoBPMXzIfPb7bs04Hur5zEI4WYgLW3Sig==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-electron": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+      "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
+      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path2d": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
+      "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.4.168",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.4.168.tgz",
+      "integrity": "sha512-MbkAjpwka/dMHaCfQ75RY1FXX3IewBVu6NGZOcxerRFlaBiIkZmUoR0jotX5VUzYZEXAGzSFtknWs5xRKliXPA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "canvas": "^2.11.2",
+        "path2d": "^0.2.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.0.tgz",
+      "integrity": "sha512-Xv5IIk+hsZmB3F2ibja/t6j/b0/1T9dtFOQacTUoLpgzRHrO6wPu1GtQ2LfRqI/imgtaapnXUgQaE8g8enPo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.0.tgz",
+      "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.0",
+        "@rollup/rollup-android-arm64": "4.52.0",
+        "@rollup/rollup-darwin-arm64": "4.52.0",
+        "@rollup/rollup-darwin-x64": "4.52.0",
+        "@rollup/rollup-freebsd-arm64": "4.52.0",
+        "@rollup/rollup-freebsd-x64": "4.52.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.0",
+        "@rollup/rollup-linux-arm64-musl": "4.52.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.0",
+        "@rollup/rollup-linux-x64-gnu": "4.52.0",
+        "@rollup/rollup-linux-x64-musl": "4.52.0",
+        "@rollup/rollup-openharmony-arm64": "4.52.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.0",
+        "@rollup/rollup-win32-x64-gnu": "4.52.0",
+        "@rollup/rollup-win32-x64-msvc": "4.52.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
+      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/tesseract.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-5.1.0.tgz",
+      "integrity": "sha512-2fH9pqWdS2C6ue/3OoGg91Wtv7Rt/1atYu/g0Q1SGFrowEW/kIBkG361hLienHsWe4KWEjxOJBrCQYpIBWG6WA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-electron": "^2.2.2",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^5.1.0",
+        "wasm-feature-detect": "^1.2.11",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-5.1.1.tgz",
+      "integrity": "sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/vite": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pdfjs-dist": "4.4.168",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "@google/genai": "^1.3.0",
-    "pdfjs-dist": "4.4.168",
+    "react-force-graph-2d": "^1.29.0",
     "tesseract.js": "5.1.0"
   },
   "devDependencies": {

--- a/services/providerClient.ts
+++ b/services/providerClient.ts
@@ -1,0 +1,483 @@
+import type { AIProviderId, ThinkingSegment } from '../types';
+import { DEFAULT_PROVIDER_MODELS } from '../constants';
+import { getProviderLabel, requiresApiKey, ANTHROPIC_API_VERSION } from './providerRegistry';
+
+export type ResponseFormat = 'text' | 'json';
+
+export type ProviderMessages = Array<{
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}>;
+
+export type ProviderCallArgs = {
+  messages: ProviderMessages;
+  maxOutputTokens?: number;
+  responseFormat?: ResponseFormat;
+  signal?: AbortSignal;
+};
+
+interface ActiveProviderConfig {
+  providerId: AIProviderId;
+  model: string;
+  apiKey?: string;
+}
+
+export interface ProviderTextResponse {
+  text: string;
+  thinking: ThinkingSegment[];
+}
+
+let activeConfig: ActiveProviderConfig = {
+  providerId: 'openai',
+  model: DEFAULT_PROVIDER_MODELS.openai,
+  apiKey: undefined,
+};
+
+const ensureConfig = (): ActiveProviderConfig => {
+  if (!activeConfig.model || activeConfig.model.trim() === '') {
+    const fallbackModel = DEFAULT_PROVIDER_MODELS[activeConfig.providerId];
+    if (!fallbackModel) {
+      throw new Error('No model configured for the selected provider. Please choose a model in settings.');
+    }
+    activeConfig = { ...activeConfig, model: fallbackModel };
+  }
+  return activeConfig;
+};
+
+export const setActiveProviderConfig = (config: { providerId: AIProviderId; model?: string; apiKey?: string }) => {
+  activeConfig = {
+    providerId: config.providerId,
+    model: config.model && config.model.trim() !== '' ? config.model.trim() : DEFAULT_PROVIDER_MODELS[config.providerId],
+    apiKey: config.apiKey && config.apiKey.trim() !== '' ? config.apiKey.trim() : undefined,
+  };
+};
+
+export const getActiveProviderConfig = (): ActiveProviderConfig => ({ ...activeConfig });
+
+export const getActiveProviderLabel = (): string => getProviderLabel(activeConfig.providerId);
+
+export const getActiveModelName = (): string => ensureConfig().model;
+
+const toOpenAIMessage = (messages: ProviderMessages) =>
+  messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+
+const THINKING_HINT_KEYWORDS = ['reason', 'think', 'analysis', 'chain', 'deliberat', 'scratchpad', 'plan', 'inner', 'cot', 'reflect'];
+const THINKING_LABEL_ALIASES: Record<string, string> = {
+  cot: 'Chain of Thought',
+  'chain_of_thought': 'Chain of Thought',
+  'chain-of-thought': 'Chain of Thought',
+  reasoning: 'Reasoning',
+  reason: 'Reasoning',
+  analysis: 'Analysis',
+  deliberate: 'Deliberation',
+  deliberation: 'Deliberation',
+  reflection: 'Reflection',
+  scratchpad: 'Scratchpad',
+  plan: 'Plan',
+  'inner_monologue': 'Inner Monologue',
+  'inner-monologue': 'Inner Monologue',
+};
+
+type NormalizedCollector = {
+  textParts: string[];
+  thinkingSegments: ThinkingSegment[];
+};
+
+const createCollector = (): NormalizedCollector => ({ textParts: [], thinkingSegments: [] });
+
+const isThinkingHint = (value?: string): boolean => {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return THINKING_HINT_KEYWORDS.some((keyword) => normalized.includes(keyword));
+};
+
+const formatThinkingLabel = (hint?: string): string => {
+  if (!hint) return 'Thinking';
+  const normalizedKey = hint.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  if (THINKING_LABEL_ALIASES[normalizedKey]) {
+    return THINKING_LABEL_ALIASES[normalizedKey];
+  }
+  const cleaned = hint.replace(/[^a-zA-Z0-9_\s-]+/g, ' ').trim();
+  if (!cleaned) {
+    return 'Thinking';
+  }
+  return cleaned
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+};
+
+const pushText = (collector: NormalizedCollector, value: unknown) => {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  collector.textParts.push(trimmed);
+};
+
+const pushThinking = (collector: NormalizedCollector, value: unknown, hint?: string) => {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  const normalizedHint = hint?.toLowerCase();
+  collector.thinkingSegments.push({
+    type: normalizedHint,
+    label: formatThinkingLabel(normalizedHint ?? hint),
+    text: trimmed,
+  });
+};
+
+const SKIP_OBJECT_KEYS = new Set([
+  'id',
+  'index',
+  'finish_reason',
+  'logprobs',
+  'usage',
+  'role',
+  'model',
+  'object',
+  'created',
+  'prompt_filter_results',
+]);
+
+const collectNormalizedParts = (value: unknown, collector: NormalizedCollector, hint?: string) => {
+  if (value == null) {
+    return;
+  }
+
+  if (typeof value === 'string') {
+    if (isThinkingHint(hint)) {
+      pushThinking(collector, value, hint);
+    } else {
+      pushText(collector, value);
+    }
+    return;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    if (!isThinkingHint(hint)) {
+      pushText(collector, String(value));
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectNormalizedParts(item, collector, hint));
+    return;
+  }
+
+  if (typeof value === 'object') {
+    const objectValue = value as Record<string, unknown>;
+    const typeHint = typeof objectValue.type === 'string' ? (objectValue.type as string) : hint;
+
+    if (typeof objectValue.text === 'string') {
+      if (isThinkingHint(typeHint)) {
+        pushThinking(collector, objectValue.text, typeHint);
+      } else {
+        pushText(collector, objectValue.text);
+      }
+    }
+
+    if (typeof objectValue.output_text === 'string') {
+      if (isThinkingHint(typeHint)) {
+        pushThinking(collector, objectValue.output_text, typeHint);
+      } else {
+        pushText(collector, objectValue.output_text);
+      }
+    }
+
+    if (typeof objectValue.message === 'string') {
+      if (isThinkingHint(typeHint)) {
+        pushThinking(collector, objectValue.message, typeHint);
+      } else {
+        pushText(collector, objectValue.message);
+      }
+    }
+
+    Object.entries(objectValue).forEach(([key, nestedValue]) => {
+      if (key === 'type' || key === 'text' || key === 'output_text' || key === 'message') {
+        return;
+      }
+      if (SKIP_OBJECT_KEYS.has(key)) {
+        return;
+      }
+      const nextHint = isThinkingHint(key) ? key : typeHint;
+      collectNormalizedParts(nestedValue, collector, nextHint);
+    });
+  }
+};
+
+const dedupeThinkingSegments = (segments: ThinkingSegment[]): ThinkingSegment[] => {
+  const seen = new Set<string>();
+  return segments
+    .map((segment) => ({ ...segment, text: segment.text.trim() }))
+    .filter((segment) => {
+      if (!segment.text) return false;
+      const key = `${segment.type ?? 'thinking'}::${segment.text}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+};
+
+const finalizeCollector = (collector: NormalizedCollector, fallback?: string): ProviderTextResponse => {
+  const textParts = collector.textParts.map((part) => part.trim()).filter(Boolean);
+  let text = textParts.join('\n\n');
+  if (!text && fallback && fallback.trim()) {
+    text = fallback.trim();
+  }
+  return {
+    text,
+    thinking: dedupeThinkingSegments(collector.thinkingSegments),
+  };
+};
+
+const extractFirstNonEmpty = (candidates: unknown[]): string | undefined => {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    } else if (Array.isArray(candidate)) {
+      const joined = candidate
+        .map((item) => {
+          if (typeof item === 'string') return item;
+          if (item && typeof item === 'object' && typeof (item as any).text === 'string') {
+            return (item as any).text;
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .join('\n\n')
+        .trim();
+      if (joined) {
+        return joined;
+      }
+    } else if (candidate && typeof candidate === 'object' && typeof (candidate as any).text === 'string') {
+      const trimmed = ((candidate as any).text as string).trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+};
+
+const callOpenAICompatible = async (
+  endpoint: string,
+  apiKey: string,
+  { messages, maxOutputTokens, responseFormat, signal }: ProviderCallArgs,
+  extraHeaders: Record<string, string> = {},
+): Promise<ProviderTextResponse> => {
+  const requestBody: Record<string, unknown> = {
+    model: ensureConfig().model,
+    messages: toOpenAIMessage(messages),
+    temperature: 0.7,
+    stream: false,
+  };
+
+  if (typeof maxOutputTokens === 'number') {
+    requestBody.max_tokens = maxOutputTokens;
+  }
+  if (responseFormat === 'json') {
+    requestBody.response_format = { type: 'json_object' };
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${apiKey}`,
+    ...extraHeaders,
+  };
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(requestBody),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Provider request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const choice = data?.choices?.[0];
+  const message = choice?.message ?? {};
+
+  const collector = createCollector();
+  collectNormalizedParts(message?.content, collector);
+  collectNormalizedParts(message?.reasoning, collector, 'reasoning');
+  collectNormalizedParts(message?.thinking, collector, 'thinking');
+  collectNormalizedParts(choice?.reasoning, collector, 'reasoning');
+  collectNormalizedParts(choice?.thinking, collector, 'thinking');
+
+  const fallback = extractFirstNonEmpty([
+    message?.content,
+    message?.text,
+    choice?.text,
+  ]);
+
+  return finalizeCollector(collector, fallback);
+};
+
+const callAnthropic = async (
+  { messages, maxOutputTokens, responseFormat, signal }: ProviderCallArgs,
+  apiKey: string,
+): Promise<ProviderTextResponse> => {
+  const systemMessage = messages.find((msg) => msg.role === 'system');
+  const conversation = messages.filter((msg) => msg.role !== 'system').map((msg) => ({
+    role: msg.role === 'assistant' ? 'assistant' : 'user',
+    content: [{ type: 'text', text: msg.content }],
+  }));
+
+  const body: Record<string, unknown> = {
+    model: ensureConfig().model,
+    max_tokens: maxOutputTokens ?? 4096,
+    temperature: 0.7,
+    messages: conversation,
+  };
+
+  if (systemMessage) {
+    body.system = systemMessage.content;
+  }
+  if (responseFormat === 'json') {
+    body.response_format = { type: 'json_object' };
+  }
+
+  const response = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_API_VERSION,
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Anthropic request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const collector = createCollector();
+  collectNormalizedParts(data?.content, collector);
+  collectNormalizedParts((data as any)?.reasoning, collector, 'reasoning');
+
+  const fallback = extractFirstNonEmpty([data?.content]);
+  const result = finalizeCollector(collector, fallback);
+  if (!result.text && result.thinking.length === 0) {
+    throw new Error('Anthropic did not return a textual response.');
+  }
+  return result;
+};
+
+const callOllama = async ({ messages, maxOutputTokens, signal }: ProviderCallArgs): Promise<ProviderTextResponse> => {
+  const systemMessages = messages.filter((msg) => msg.role === 'system');
+  const conversation = messages.filter((msg) => msg.role !== 'system');
+
+  const promptSections: string[] = [];
+  if (systemMessages.length > 0) {
+    promptSections.push(`System:\n${systemMessages.map((msg) => msg.content).join('\n\n')}`);
+  }
+
+  conversation.forEach((msg) => {
+    const speaker = msg.role === 'assistant' ? 'Assistant' : 'User';
+    promptSections.push(`${speaker}: ${msg.content}`);
+  });
+  promptSections.push('Assistant:');
+
+  const body: Record<string, unknown> = {
+    model: ensureConfig().model,
+    prompt: promptSections.join('\n\n'),
+    stream: false,
+  };
+
+  if (typeof maxOutputTokens === 'number') {
+    body.options = { num_predict: maxOutputTokens };
+  }
+
+  const response = await fetch('http://127.0.0.1:11434/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Ollama request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (!data || typeof data.response !== 'string') {
+    throw new Error('Ollama did not return a textual response.');
+  }
+  return { text: data.response, thinking: [] };
+};
+
+export const callProvider = async ({ messages, maxOutputTokens, responseFormat = 'text', signal }: ProviderCallArgs): Promise<ProviderTextResponse> => {
+  if (signal?.aborted) {
+    throw new DOMException('Aborted by user', 'AbortError');
+  }
+
+  const config = ensureConfig();
+  const providerLabel = getProviderLabel(config.providerId);
+  const apiKey = config.apiKey;
+
+  if (requiresApiKey(config.providerId) && !apiKey) {
+    throw new Error(`${providerLabel} requires an API key. Please add it in settings before running this action.`);
+  }
+
+  try {
+    switch (config.providerId) {
+      case 'openai':
+        return await callOpenAICompatible('https://api.openai.com/v1/chat/completions', apiKey!, {
+          messages,
+          maxOutputTokens,
+          responseFormat,
+          signal,
+        });
+      case 'openrouter': {
+        const referer = typeof window !== 'undefined' ? window.location.origin : 'https://local.app';
+        return await callOpenAICompatible(
+          'https://openrouter.ai/api/v1/chat/completions',
+          apiKey!,
+          { messages, maxOutputTokens, responseFormat, signal },
+          { 'HTTP-Referer': referer, 'X-Title': 'AI Content Suite' },
+        );
+      }
+      case 'xai':
+        return await callOpenAICompatible('https://api.x.ai/v1/chat/completions', apiKey!, {
+          messages,
+          maxOutputTokens,
+          responseFormat,
+          signal,
+        });
+      case 'deepseek':
+        return await callOpenAICompatible('https://api.deepseek.com/chat/completions', apiKey!, {
+          messages,
+          maxOutputTokens,
+          responseFormat,
+          signal,
+        });
+      case 'anthropic':
+        return await callAnthropic({ messages, maxOutputTokens, responseFormat, signal }, apiKey!);
+      case 'ollama':
+        return await callOllama({ messages, maxOutputTokens, responseFormat, signal });
+      default:
+        throw new Error(`Unsupported provider: ${config.providerId}`);
+    }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
+    throw new Error(`${providerLabel} request failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+};

--- a/services/providerRegistry.ts
+++ b/services/providerRegistry.ts
@@ -1,0 +1,171 @@
+import type { AIProviderId, EmbeddingProviderId, ModelOption } from '../types';
+
+export interface ProviderInfo {
+  id: AIProviderId;
+  label: string;
+  requiresApiKey: boolean;
+  docsUrl?: string;
+}
+
+export interface EmbeddingProviderInfo {
+  id: EmbeddingProviderId;
+  label: string;
+  requiresApiKey: boolean;
+  docsUrl?: string;
+  defaultEndpoint?: string;
+}
+
+export const ANTHROPIC_API_VERSION = '2023-06-01';
+
+export const AI_PROVIDERS: ProviderInfo[] = [
+  { id: 'openai', label: 'OpenAI', requiresApiKey: true, docsUrl: 'https://platform.openai.com/' },
+  { id: 'openrouter', label: 'OpenRouter', requiresApiKey: true, docsUrl: 'https://openrouter.ai/' },
+  { id: 'xai', label: 'xAI (Grok)', requiresApiKey: true, docsUrl: 'https://docs.x.ai/' },
+  { id: 'deepseek', label: 'DeepSeek', requiresApiKey: true, docsUrl: 'https://platform.deepseek.com/' },
+  { id: 'anthropic', label: 'Anthropic', requiresApiKey: true, docsUrl: 'https://docs.anthropic.com/' },
+  { id: 'ollama', label: 'Ollama (Local)', requiresApiKey: false, docsUrl: 'https://ollama.com/' },
+];
+
+const PROVIDER_LABEL_MAP: Record<AIProviderId, ProviderInfo> = AI_PROVIDERS.reduce((acc, provider) => {
+  acc[provider.id] = provider;
+  return acc;
+}, {} as Record<AIProviderId, ProviderInfo>);
+
+export const EMBEDDING_PROVIDERS: EmbeddingProviderInfo[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.openai.com/docs/guides/embeddings',
+    defaultEndpoint: 'https://api.openai.com/v1/embeddings',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    requiresApiKey: true,
+    docsUrl: 'https://openrouter.ai/docs#embeddings',
+    defaultEndpoint: 'https://openrouter.ai/api/v1/embeddings',
+  },
+  {
+    id: 'deepseek',
+    label: 'DeepSeek',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.deepseek.com/docs/api/embeddings',
+    defaultEndpoint: 'https://api.deepseek.com/v1/embeddings',
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (Local)',
+    requiresApiKey: false,
+    docsUrl: 'https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings',
+    defaultEndpoint: 'http://127.0.0.1:11434/api/embeddings',
+  },
+  {
+    id: 'custom',
+    label: 'Custom (OpenAI-compatible)',
+    requiresApiKey: false,
+  },
+];
+
+const EMBEDDING_PROVIDER_MAP: Record<EmbeddingProviderId, EmbeddingProviderInfo> = EMBEDDING_PROVIDERS.reduce((acc, provider) => {
+  acc[provider.id] = provider;
+  return acc;
+}, {} as Record<EmbeddingProviderId, EmbeddingProviderInfo>);
+
+export const requiresApiKey = (providerId: AIProviderId): boolean => PROVIDER_LABEL_MAP[providerId]?.requiresApiKey ?? true;
+
+export const getProviderLabel = (providerId: AIProviderId): string => PROVIDER_LABEL_MAP[providerId]?.label ?? providerId;
+
+export const requiresEmbeddingApiKey = (providerId: EmbeddingProviderId): boolean =>
+  EMBEDDING_PROVIDER_MAP[providerId]?.requiresApiKey ?? true;
+
+export const getEmbeddingProviderLabel = (providerId: EmbeddingProviderId): string =>
+  EMBEDDING_PROVIDER_MAP[providerId]?.label ?? providerId;
+
+export const getEmbeddingProviderDefaultEndpoint = (providerId: EmbeddingProviderId): string | undefined =>
+  EMBEDDING_PROVIDER_MAP[providerId]?.defaultEndpoint;
+
+export const fetchModelsForProvider = async (
+  providerId: AIProviderId,
+  apiKey?: string,
+  signal?: AbortSignal,
+): Promise<ModelOption[]> => {
+  switch (providerId) {
+    case 'openai': {
+      if (!apiKey) throw new Error('An OpenAI API key is required to load models.');
+      const response = await fetch('https://api.openai.com/v1/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`OpenAI model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.id }));
+    }
+    case 'openrouter': {
+      const response = await fetch('https://openrouter.ai/api/v1/models', { signal });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`OpenRouter model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.name || model.id }));
+    }
+    case 'xai': {
+      if (!apiKey) throw new Error('An xAI API key is required to load models.');
+      const response = await fetch('https://api.x.ai/v1/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`xAI model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      const models = Array.isArray(data?.data) ? data.data : data?.models;
+      return (models || []).map((model: any) => ({ id: model.id ?? model.name, label: model.id ?? model.name }));
+    }
+    case 'deepseek': {
+      if (!apiKey) throw new Error('A DeepSeek API key is required to load models.');
+      const response = await fetch('https://api.deepseek.com/models', {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`DeepSeek model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.id }));
+    }
+    case 'anthropic': {
+      if (!apiKey) throw new Error('An Anthropic API key is required to load models.');
+      const response = await fetch('https://api.anthropic.com/v1/models', {
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': ANTHROPIC_API_VERSION,
+        },
+        signal,
+      });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`Anthropic model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.data || []).map((model: any) => ({ id: model.id, label: model.display_name || model.id }));
+    }
+    case 'ollama': {
+      const response = await fetch('http://127.0.0.1:11434/api/tags', { signal });
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        throw new Error(`Ollama model request failed (${response.status}): ${errorText || response.statusText}`);
+      }
+      const data = await response.json();
+      return (data?.models || []).map((model: any) => ({ id: model?.name ?? model?.model, label: model?.name ?? model?.model }));
+    }
+    default:
+      return [];
+  }
+};

--- a/services/reasoningService.ts
+++ b/services/reasoningService.ts
@@ -1,7 +1,7 @@
 
 
 import type { ProgressUpdate, ReasoningOutput, ReasoningSettings, ReasoningNode, ReasoningNodeType, ReasoningTree } from '../types';
-import { generateText } from './geminiService';
+import { generateText, getActiveModelName } from './geminiService';
 // FIX: Corrected import path for reasoning prompts
 import * as Prompts from '../prompts/reasoning/index';
 import { processTranscript } from './summarizationService';
@@ -186,7 +186,7 @@ export const processReasoningRequest = async (
             exported_at: new Date().toISOString(),
         },
         audit: {
-            model: 'gemini-2.5-flash',
+            model: getActiveModelName(),
             tokens_in: 0,
             tokens_out: 0,
             cost_usd: 0.0,

--- a/services/reportGenerator.ts
+++ b/services/reportGenerator.ts
@@ -1,6 +1,7 @@
 
 
 import type { ProcessedOutput, Mode, SummaryOutput, StyleModelOutput, RewriterOutput, MathFormatterOutput } from '../types';
+import { getActiveModelName, getActiveProviderLabel } from './geminiService';
 
 declare var marked: any;
 declare var hljs: any;
@@ -29,6 +30,14 @@ const formatDate = (date: Date) => {
   });
 };
 
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 const generateHtmlReport = (output: ProcessedOutput, mode: Mode, styleTarget?: string, suggestions?: string[] | null): string => {
   const generationDate = formatDate(new Date());
   const isTechnical = mode === 'technical' && 'finalSummary' in output;
@@ -40,6 +49,11 @@ const generateHtmlReport = (output: ProcessedOutput, mode: Mode, styleTarget?: s
   const styleOutput = isStyle ? output as StyleModelOutput : null;
   const rewriterOutput = isRewriter ? output as RewriterOutput : null;
   const formatterOutput = isFormatter ? output as MathFormatterOutput : null;
+
+  const providerLabel = getActiveProviderLabel();
+  const modelName = getActiveModelName();
+  const providerSummary = modelName ? `${providerLabel} • ${modelName}` : providerLabel;
+  const providerSummaryHtml = escapeHtml(providerSummary);
 
   const title = isTechnical 
     ? 'Technical Summary Report' 
@@ -282,7 +296,7 @@ ${techOutput.mermaidDiagram}
     </div>
     ${bodyContent}
     <div class="footer">
-      <p>Powered by AI Content Suite & Gemini</p>
+      <p>Powered by AI Content Suite • ${providerSummaryHtml}</p>
     </div>
   </div>
   <script>
@@ -386,7 +400,10 @@ const generateMarkdownReport = (output: ProcessedOutput, mode: Mode, styleTarget
   }
 
   content += `---\n\n`;
-  content += `*Powered by AI Content Suite & Gemini*\n`;
+  const providerLabel = getActiveProviderLabel();
+  const modelName = getActiveModelName();
+  const providerSummary = modelName ? `${providerLabel} • ${modelName}` : providerLabel;
+  content += `*Powered by AI Content Suite • ${providerSummary}*\n`;
 
   return content;
 };

--- a/services/vectorStoreService.ts
+++ b/services/vectorStoreService.ts
@@ -1,0 +1,189 @@
+import type { EmbeddingSettings, VectorStoreMatch, VectorStoreSettings } from '../types';
+import { getEmbeddingProviderDefaultEndpoint } from './providerRegistry';
+
+const DEFAULT_QDRANT_TOP_K = 5;
+const MAX_QDRANT_TOP_K = 20;
+
+const getEmbeddingEndpoint = (embedding: EmbeddingSettings): string | null => {
+  const customEndpoint = embedding.baseUrl?.trim();
+  if (customEndpoint) {
+    return customEndpoint;
+  }
+  const defaultEndpoint = getEmbeddingProviderDefaultEndpoint(embedding.provider)?.trim();
+  if (defaultEndpoint) {
+    return defaultEndpoint;
+  }
+  return null;
+};
+
+const buildEmbeddingHeaders = (embedding: EmbeddingSettings): Record<string, string> => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = embedding.apiKey?.trim();
+  if (embedding.provider !== 'ollama' && apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+  if (embedding.provider === 'openrouter') {
+    const referer = typeof window !== 'undefined' ? window.location.origin : 'https://local.app';
+    headers['HTTP-Referer'] = referer;
+    headers['X-Title'] = 'AI Content Suite';
+  }
+  return headers;
+};
+
+const requestEmbedding = async (text: string, embedding: EmbeddingSettings, signal?: AbortSignal): Promise<number[]> => {
+  const endpoint = getEmbeddingEndpoint(embedding);
+  if (!endpoint) {
+    throw new Error('No embedding endpoint configured for the selected provider.');
+  }
+
+  const headers = buildEmbeddingHeaders(embedding);
+  const body: Record<string, unknown> = { model: embedding.model.trim() };
+
+  if (!body.model) {
+    throw new Error('An embedding model is required to query the vector store.');
+  }
+
+  if (embedding.provider === 'ollama') {
+    body.prompt = text;
+  } else {
+    body.input = text;
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Embedding request failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  if (embedding.provider === 'ollama') {
+    const vector = data?.embedding;
+    if (!Array.isArray(vector)) {
+      throw new Error('Ollama returned an unexpected embedding payload.');
+    }
+    return vector.map((value: unknown) => Number(value));
+  }
+
+  const vector = data?.data?.[0]?.embedding;
+  if (!Array.isArray(vector)) {
+    throw new Error('Embedding provider did not return a valid vector.');
+  }
+  return vector.map((value: unknown) => Number(value));
+};
+
+const buildQdrantHeaders = (apiKey?: string): Record<string, string> => {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey && apiKey.trim() !== '') {
+    headers['api-key'] = apiKey.trim();
+  }
+  return headers;
+};
+
+const extractPayloadText = (payload: unknown): { text: string | null; metadata?: Record<string, unknown> } => {
+  if (!payload || typeof payload !== 'object') {
+    if (typeof payload === 'string') {
+      return { text: payload };
+    }
+    return { text: null };
+  }
+
+  const payloadRecord = payload as Record<string, unknown>;
+  const candidateKeys = ['text', 'content', 'chunk', 'document', 'body', 'summary'];
+
+  for (const key of candidateKeys) {
+    const value = payloadRecord[key];
+    if (typeof value === 'string' && value.trim() !== '') {
+      const metadata = { ...payloadRecord };
+      delete metadata[key];
+      return { text: value, metadata: Object.keys(metadata).length > 0 ? metadata : undefined };
+    }
+    if (Array.isArray(value) && value.every(item => typeof item === 'string')) {
+      const joined = (value as string[]).join('\n');
+      const metadata = { ...payloadRecord };
+      delete metadata[key];
+      return { text: joined, metadata: Object.keys(metadata).length > 0 ? metadata : undefined };
+    }
+  }
+
+  return { text: JSON.stringify(payloadRecord) };
+};
+
+const queryQdrant = async (
+  settings: VectorStoreSettings,
+  embeddingVector: number[],
+  signal?: AbortSignal,
+): Promise<VectorStoreMatch[]> => {
+  const baseUrl = (settings.url || '').trim().replace(/\/$/, '');
+  const collection = (settings.collection || '').trim();
+
+  if (!baseUrl || !collection) {
+    throw new Error('Qdrant URL and collection are required to fetch context.');
+  }
+
+  const searchUrl = `${baseUrl}/collections/${encodeURIComponent(collection)}/points/search`;
+  const limit = Math.min(Math.max(Math.round(settings.topK || DEFAULT_QDRANT_TOP_K), 1), MAX_QDRANT_TOP_K);
+
+  const response = await fetch(searchUrl, {
+    method: 'POST',
+    headers: buildQdrantHeaders(settings.apiKey),
+    body: JSON.stringify({
+      vector: embeddingVector,
+      limit,
+      with_payload: true,
+      with_vectors: false,
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Qdrant search failed (${response.status}): ${errorText || response.statusText}`);
+  }
+
+  const data = await response.json();
+  const results = Array.isArray(data?.result) ? data.result : [];
+
+  return results
+    .map((item: any) => {
+      const score = typeof item?.score === 'number' ? item.score : 0;
+      const payload = extractPayloadText(item?.payload);
+      if (!payload.text) {
+        return null;
+      }
+      return {
+        text: payload.text,
+        score,
+        metadata: payload.metadata,
+      } as VectorStoreMatch;
+    })
+    .filter((match): match is VectorStoreMatch => Boolean(match));
+};
+
+export const fetchVectorStoreContext = async (
+  text: string,
+  settings: VectorStoreSettings,
+  signal?: AbortSignal,
+): Promise<VectorStoreMatch[]> => {
+  if (!settings.enabled) {
+    return [];
+  }
+
+  const trimmedText = text.trim();
+  if (!trimmedText) {
+    return [];
+  }
+
+  try {
+    const vector = await requestEmbedding(trimmedText, settings.embedding, signal);
+    return await queryQdrant(settings, vector, signal);
+  } catch (error) {
+    console.warn('Vector store lookup failed:', error);
+    return [];
+  }
+};

--- a/types.ts
+++ b/types.ts
@@ -314,15 +314,62 @@ export interface SavedPrompt {
   prompt: string;
 }
 
+export type AIProviderId = 'xai' | 'openrouter' | 'openai' | 'deepseek' | 'anthropic' | 'ollama';
+
+export type EmbeddingProviderId = 'openai' | 'openrouter' | 'deepseek' | 'ollama' | 'custom';
+
+export interface ModelOption {
+  id: string;
+  label: string;
+}
+
+export type ProviderApiKeys = Partial<Record<AIProviderId, string>>;
+
+export interface EmbeddingSettings {
+  provider: EmbeddingProviderId;
+  model: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface VectorStoreSettings {
+  enabled: boolean;
+  url: string;
+  apiKey?: string;
+  collection: string;
+  topK: number;
+  embedding: EmbeddingSettings;
+}
+
+export interface VectorStoreMatch {
+  text: string;
+  score: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AIProviderSettings {
+  selectedProvider: AIProviderId;
+  selectedModel: string;
+  apiKeys: ProviderApiKeys;
+}
+
 export interface ChatSettings {
   systemInstruction: string;
+  vectorStore?: VectorStoreSettings;
 }
 
 export type ChatMessagePart = { text: string } | { inlineData: { mimeType: string; data: string } };
 
+export interface ThinkingSegment {
+  type?: string;
+  label: string;
+  text: string;
+}
+
 export interface ChatMessage {
     role: 'user' | 'model';
     parts: ChatMessagePart[];
+    thinking?: ThinkingSegment[];
 }
 
 export interface ChatOutput {

--- a/utils/deepClone.ts
+++ b/utils/deepClone.ts
@@ -1,0 +1,6 @@
+export function deepClone<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/utils/fileUtils.ts
+++ b/utils/fileUtils.ts
@@ -13,10 +13,10 @@ export const readFileAsText = (file: File): Promise<string> => {
 };
 
 /**
- * Converts a File object to a Gemini GenerativePart.
+ * Converts a File object to a provider-agnostic chat message part.
  * Handles images by converting to base64 and other files as text.
  * @param file The file to convert.
- * @returns A promise that resolves to a GenerativePart object.
+ * @returns A promise that resolves to a message part object understood by supported providers.
  */
 export const fileToGenerativePart = async (file: File): Promise<any> => {
     if (file.type.startsWith('image/')) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,12 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
+    const defaultApiKey = env.AI_CONTENT_SUITE_DEFAULT_API_KEY ?? env.API_KEY ?? '';
     return {
       plugins: [react()],
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.API_KEY': JSON.stringify(defaultApiKey),
+        'process.env.AI_CONTENT_SUITE_DEFAULT_API_KEY': JSON.stringify(defaultApiKey),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- replace the legacy monolithic App layout with a WorkspaceLayout shell so the UI width slider, sidebar, and content panes stay consistent across tabs
- introduce persistent workspace hooks for chat/provider settings, saved prompts, and layout state so mode state survives tab switches without resets
- move chat submission handling into a reusable hook and keep App.tsx under 500 lines while wiring a collapsible sidebar and adjustable width controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce30c6f99c832694fdbf73bbd102f0