### PR TITLE
Add global settings menu with provider overrides

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,20 +1,18 @@
 
 
 
-import React, { useState, useCallback, useMemo, useEffect, FormEvent, useRef } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { ProgressBar } from './components/ui/ProgressBar';
 import { Tabs } from './components/ui/Tabs';
 import { ReportModal } from './components/modals/ReportModal';
-import { ChatSettingsModal } from './components/modals/ChatSettingsModal';
+import { SettingsModal } from './components/modals/SettingsModal';
 import { useStarfield } from './hooks/useStarfield';
 import type { ProcessedOutput, ProgressUpdate, AppState, ProcessingError, Mode, RewriteLength, SummaryFormat, ReasoningSettings, ScaffolderSettings, RequestSplitterSettings, PromptEnhancerSettings, AgentDesignerSettings, ChatSettings, ChatMessage, SavedPrompt, AIProviderSettings } from './types';
-import { INITIAL_PROGRESS, INITIAL_REASONING_SETTINGS, INITIAL_SCAFFOLDER_SETTINGS, INITIAL_REQUEST_SPLITTER_SETTINGS, INITIAL_PROMPT_ENHANCER_SETTINGS, INITIAL_AGENT_DESIGNER_SETTINGS, INITIAL_CHAT_SETTINGS, INITIAL_AI_PROVIDER_SETTINGS, DEFAULT_PROVIDER_MODELS } from './constants';
-import { SUMMARY_FORMAT_OPTIONS } from './data/summaryFormats';
+import { INITIAL_PROGRESS, INITIAL_REASONING_SETTINGS, INITIAL_SCAFFOLDER_SETTINGS, INITIAL_REQUEST_SPLITTER_SETTINGS, INITIAL_PROMPT_ENHANCER_SETTINGS, INITIAL_AGENT_DESIGNER_SETTINGS, INITIAL_CHAT_SETTINGS } from './constants';
 import { TABS, DESCRIPTION_TEXT, getButtonText } from './constants/uiConstants';
 import { handleSubmission } from './services/submissionService';
-import { setActiveProviderConfig, sendChatMessage } from './services/geminiService';
-import { AI_PROVIDERS, fetchModelsForProvider, getProviderLabel } from './services/providerRegistry';
-import { fileToGenerativePart } from './utils/fileUtils';
+import { setActiveProviderConfig } from './services/geminiService';
+import { AI_PROVIDERS, fetchModelsForProvider } from './services/providerRegistry';
 import {
   downloadReasoningArtifact,
   downloadScaffoldArtifact,
@@ -22,6 +20,16 @@ import {
   downloadPromptEnhancerArtifact,
   downloadAgentDesignerArtifact,
 } from './utils/downloadUtils';
+import { useWorkspaceState } from './hooks/useWorkspaceState';
+import { usePersistentChatSettings } from './hooks/usePersistentChatSettings';
+import { usePersistentProviderSettings } from './hooks/usePersistentProviderSettings';
+import { useSavedPrompts } from './hooks/useSavedPrompts';
+import { useLayoutPreferences } from './hooks/useLayoutPreferences';
+import { useMainFormProps } from './hooks/useMainFormProps';
+import { useChatSubmission } from './hooks/useChatSubmission';
+import { deepClone } from './utils/deepClone';
+import { XCircleIcon } from './components/icons/XCircleIcon';
+import { MenuBar } from './components/layouts/MenuBar';
 
 // Import new modular components
 import { ChatInterface } from './components/layouts/ChatInterface';
@@ -30,9 +38,6 @@ import { SubmitButton } from './components/ui/SubmitButton';
 import { StopButton } from './components/ui/StopButton';
 import { ResultsViewer } from './components/layouts/ResultsViewer';
 
-
-const PROVIDER_SETTINGS_STORAGE_KEY = 'ai_content_suite_provider_settings';
-const CHAT_SETTINGS_STORAGE_KEY = 'ai_content_suite_chat_settings';
 
 const App: React.FC = () => {
   const [activeMode, setActiveMode] = useState<Mode>('technical');
@@ -45,47 +50,20 @@ const App: React.FC = () => {
   } = useWorkspaceState(activeMode);
   const abortControllersRef = useRef<Partial<Record<Mode, AbortController>>>({});
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  // --- MODE-SPECIFIC SETTINGS ---
-  const [styleTarget, setStyleTarget] = useState<string>('');
-  const [rewriteStyle, setRewriteStyle] = useState<string>('');
-  const [rewriteInstructions, setRewriteInstructions] = useState<string>('');
-  const [rewriteLength, setRewriteLength] = useState<RewriteLength>('medium');
-  const [useHierarchical, setUseHierarchical] = useState(false);
-  const [summaryFormat, setSummaryFormat] = useState<SummaryFormat>('default');
-  const [summarySearchTerm, setSummarySearchTerm] = useState('');
-  const [summaryTextInput, setSummaryTextInput] = useState('');
-  const [reasoningPrompt, setReasoningPrompt] = useState('');
-  const [reasoningSettings, setReasoningSettings] = useState<ReasoningSettings>(INITIAL_REASONING_SETTINGS);
-  const [scaffolderPrompt, setScaffolderPrompt] = useState('');
-  const [scaffolderSettings, setScaffolderSettings] = useState<ScaffolderSettings>(INITIAL_SCAFFOLDER_SETTINGS);
-  const [requestSplitterSpec, setRequestSplitterSpec] = useState('');
-  const [requestSplitterSettings, setRequestSplitterSettings] = useState<RequestSplitterSettings>(INITIAL_REQUEST_SPLITTER_SETTINGS);
-  const [promptEnhancerSettings, setPromptEnhancerSettings] = useState<PromptEnhancerSettings>(INITIAL_PROMPT_ENHANCER_SETTINGS);
-  const [agentDesignerSettings, setAgentDesignerSettings] = useState<AgentDesignerSettings>(INITIAL_AGENT_DESIGNER_SETTINGS);
-
-  // --- CHAT-SPECIFIC STATE ---
-  const [chatSettings, setChatSettings] = useState<ChatSettings>(INITIAL_CHAT_SETTINGS);
-  const [aiProviderSettings, setAiProviderSettings] = useState<AIProviderSettings>(INITIAL_AI_PROVIDER_SETTINGS);
-  const [savedPrompts, setSavedPrompts] = useState<SavedPrompt[]>([]);
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
-  const [isStreamingResponse, setIsStreamingResponse] = useState(false);
-  const [chatInput, setChatInput] = useState('');
-  const [chatFiles, setChatFiles] = useState<File[] | null>(null);
-  const [isChatSettingsModalOpen, setIsChatSettingsModalOpen] = useState(false);
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
 
   const { chatSettings, setChatSettings } = usePersistentChatSettings();
   const {
     providerSettings: aiProviderSettings,
     setProviderSettings: setAiProviderSettings,
+    resolveProviderForMode,
     activeProviderInfo,
     activeProviderLabel,
     activeModelName,
     providerStatusText,
     providerStatusTone,
     providerSummaryText,
-  } = usePersistentProviderSettings();
+  } = usePersistentProviderSettings(activeMode);
   const { savedPrompts, setSavedPrompts } = useSavedPrompts();
   const {
     isSidebarCollapsed,
@@ -103,12 +81,21 @@ const App: React.FC = () => {
     processedData,
     error,
     nextStepSuggestions,
+    suggestionsLoading,
     styleTarget,
+    rewriteStyle,
+    rewriteInstructions,
+    rewriteLength,
+    useHierarchical,
+    summaryFormat,
+    summarySearchTerm,
     summaryTextInput,
     reasoningPrompt,
+    reasoningSettings,
     scaffolderPrompt,
     scaffolderSettings,
     requestSplitterSpec,
+    requestSplitterSettings,
     promptEnhancerSettings,
     agentDesignerSettings,
     chatHistory,
@@ -119,115 +106,17 @@ const App: React.FC = () => {
 
   useStarfield('space-background');
 
-  // --- EFFECTS ---
   useEffect(() => {
-    try {
-      const savedSettings = localStorage.getItem(CHAT_SETTINGS_STORAGE_KEY);
-      if (savedSettings) {
-        const parsed = JSON.parse(savedSettings);
-        if (parsed && typeof parsed === 'object') {
-          const defaults = INITIAL_CHAT_SETTINGS.vectorStore;
-          const parsedVectorStore = parsed.vectorStore && typeof parsed.vectorStore === 'object' ? parsed.vectorStore : {};
-          const mergedVectorStore = defaults
-            ? {
-                ...defaults,
-                ...parsedVectorStore,
-                embedding: {
-                  ...defaults.embedding,
-                  ...(parsedVectorStore.embedding ?? {}),
-                },
-              }
-            : parsedVectorStore;
-
-          setChatSettings({
-            ...INITIAL_CHAT_SETTINGS,
-            ...parsed,
-            vectorStore: mergedVectorStore,
-          });
-        }
-      }
-    } catch (error) {
-      console.error('Failed to load chat settings from local storage:', error);
-    }
-  }, []);
-
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem(PROVIDER_SETTINGS_STORAGE_KEY);
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        const availableProviders = new Set(AI_PROVIDERS.map(provider => provider.id));
-        const providerId = (availableProviders.has(parsed.selectedProvider)
-          ? parsed.selectedProvider
-          : INITIAL_AI_PROVIDER_SETTINGS.selectedProvider) as AIProviderSettings['selectedProvider'];
-        const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? DEFAULT_PROVIDER_MODELS[INITIAL_AI_PROVIDER_SETTINGS.selectedProvider];
-        const selectedModel = typeof parsed.selectedModel === 'string' && parsed.selectedModel.trim() !== ''
-          ? parsed.selectedModel
-          : fallbackModel;
-        const apiKeys = parsed.apiKeys && typeof parsed.apiKeys === 'object' && parsed.apiKeys !== null ? parsed.apiKeys : {};
-        setAiProviderSettings({ selectedProvider: providerId, selectedModel, apiKeys });
-      }
-    } catch (e) {
-      console.error('Failed to load provider settings from local storage:', e);
-    }
-  }, []);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(PROVIDER_SETTINGS_STORAGE_KEY, JSON.stringify(aiProviderSettings));
-    } catch (e) {
-      console.error('Failed to save provider settings to local storage:', e);
-    }
-  }, [aiProviderSettings]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(CHAT_SETTINGS_STORAGE_KEY, JSON.stringify(chatSettings));
-    } catch (error) {
-      console.error('Failed to save chat settings to local storage:', error);
-    }
-  }, [chatSettings]);
-
-  useEffect(() => {
-    const apiKey = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
-    const model = aiProviderSettings.selectedModel && aiProviderSettings.selectedModel.trim() !== ''
-      ? aiProviderSettings.selectedModel
-      : DEFAULT_PROVIDER_MODELS[aiProviderSettings.selectedProvider];
+    const { providerId, model } = resolveProviderForMode(activeMode);
+    const apiKey = aiProviderSettings.apiKeys?.[providerId];
     setActiveProviderConfig({
-      providerId: aiProviderSettings.selectedProvider,
+      providerId,
       model,
       apiKey,
     });
-  }, [aiProviderSettings]);
-
-  // Load saved prompts from local storage on mount
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('ai_content_suite_saved_prompts');
-      if (saved) {
-        setSavedPrompts(JSON.parse(saved));
-      }
-    } catch (e) {
-      console.error("Failed to load saved prompts from local storage:", e);
-    }
-  }, []);
-
-  // Save prompts to local storage whenever they change
-  useEffect(() => {
-    try {
-      localStorage.setItem('ai_content_suite_saved_prompts', JSON.stringify(savedPrompts));
-    } catch (e) {
-      console.error("Failed to save prompts to local storage:", e);
-    }
-  }, [savedPrompts]);
+  }, [activeMode, aiProviderSettings.apiKeys, resolveProviderForMode]);
 
   // Effect to handle state changes for cancellation
-  useEffect(() => {
-    if (appState === 'cancelled') {
-      handleReset();
-    }
-  }, [appState]);
-
   // --- MEMOS ---
   const canSubmit = useMemo(() => {
     const hasFiles = currentFiles && currentFiles.length > 0;
@@ -268,50 +157,6 @@ const App: React.FC = () => {
     isStreamingResponse,
   ]);
 
-  const activeProviderLabel = useMemo(
-    () => getProviderLabel(aiProviderSettings.selectedProvider),
-    [aiProviderSettings.selectedProvider],
-  );
-
-  const activeProviderInfo = useMemo(
-    () => AI_PROVIDERS.find(provider => provider.id === aiProviderSettings.selectedProvider),
-    [aiProviderSettings.selectedProvider],
-  );
-
-  const activeModelName = useMemo(() => {
-    const trimmed = aiProviderSettings.selectedModel?.trim();
-    if (trimmed && trimmed.length > 0) {
-      return trimmed;
-    }
-    return DEFAULT_PROVIDER_MODELS[aiProviderSettings.selectedProvider] ?? '';
-  }, [aiProviderSettings]);
-
-  const isApiKeyConfigured = useMemo(() => {
-    const key = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
-    return typeof key === 'string' && key.trim() !== '';
-  }, [aiProviderSettings]);
-
-  const providerStatusText = useMemo(() => {
-    if (!activeProviderInfo) return 'Provider status unavailable';
-    if (activeProviderInfo.requiresApiKey) {
-      return isApiKeyConfigured ? 'API key saved' : 'API key required';
-    }
-    return 'API key optional';
-  }, [activeProviderInfo, isApiKeyConfigured]);
-
-  const providerStatusTone = useMemo(() => {
-    if (!activeProviderInfo) return 'text-destructive';
-    if (activeProviderInfo.requiresApiKey) {
-      return isApiKeyConfigured ? 'text-emerald-400' : 'text-destructive';
-    }
-    return 'text-text-secondary';
-  }, [activeProviderInfo, isApiKeyConfigured]);
-
-  const providerSummaryText = useMemo(
-    () => (activeModelName ? `${activeProviderLabel} • ${activeModelName}` : activeProviderLabel),
-    [activeProviderLabel, activeModelName],
-  );
-
   const buttonText = useMemo(() => {
     return getButtonText(
       activeMode,
@@ -326,57 +171,36 @@ const App: React.FC = () => {
   }, [activeMode, currentFiles, summaryTextInput, reasoningPrompt, scaffolderPrompt, requestSplitterSpec, promptEnhancerSettings.rawPrompt, agentDesignerSettings.goal]);
   
   // --- EVENT HANDLERS ---
-  const handleReset = useCallback(() => {
-    if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-    }
-    setCurrentFiles(null);
-    setProcessedData(null);
-    setError(null);
-    setAppState('idle');
-    setProgress(INITIAL_PROGRESS);
-    setStyleTarget('');
-    setRewriteStyle('');
-    setRewriteInstructions('');
-    setRewriteLength('medium');
-    setNextStepSuggestions(null);
-    setSuggestionsLoading(false);
-    setUseHierarchical(false);
-    setSummaryFormat('default');
-    setSummarySearchTerm('');
-    setSummaryTextInput('');
-    setReasoningPrompt('');
-    setReasoningSettings(INITIAL_REASONING_SETTINGS);
-    setScaffolderPrompt('');
-    setScaffolderSettings(INITIAL_SCAFFOLDER_SETTINGS);
-    setRequestSplitterSpec('');
-    setRequestSplitterSettings(INITIAL_REQUEST_SPLITTER_SETTINGS);
-    setPromptEnhancerSettings(INITIAL_PROMPT_ENHANCER_SETTINGS);
-    setAgentDesignerSettings(INITIAL_AGENT_DESIGNER_SETTINGS);
-    setChatSettings(INITIAL_CHAT_SETTINGS);
-    setChatHistory([]);
-    setIsStreamingResponse(false);
-    setChatInput('');
-    setChatFiles(null);
-  }, []);
-  
+  const handleReset = useCallback(
+    (mode: Mode = activeMode) => {
+      const controller = abortControllersRef.current[mode];
+      if (controller) {
+        controller.abort();
+        delete abortControllersRef.current[mode];
+      }
+      resetMode(mode);
+      setIsReportModalOpen(false);
+    },
+    [activeMode, resetMode],
+  );
+
   const handleStop = useCallback(() => {
-    if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
+    const controller = abortControllersRef.current[activeMode];
+    if (controller) {
+      controller.abort();
+      delete abortControllersRef.current[activeMode];
     }
-    setAppState('cancelled');
-  }, []);
+    setModeValue('appState', 'cancelled');
+  }, [activeMode, setModeValue]);
 
   const handleSubmit = useCallback(() => {
     const modeAtSubmission = activeMode;
     const controller = new AbortController();
     abortControllersRef.current[modeAtSubmission] = controller;
-    const { signal } = controller;
 
     const stateForMode = getStateForMode(modeAtSubmission);
 
-    handleSubmission({
+    const submissionPromise = handleSubmission({
       activeMode: modeAtSubmission,
       currentFiles: stateForMode.currentFiles,
       settings: {
@@ -403,113 +227,60 @@ const App: React.FC = () => {
       setProgress: value => setModeValue('progress', value, modeAtSubmission),
       setNextStepSuggestions: value => setModeValue('nextStepSuggestions', value, modeAtSubmission),
       setSuggestionsLoading: value => setModeValue('suggestionsLoading', value, modeAtSubmission),
-      signal,
+      signal: controller.signal,
     });
-  }, [
-    activeMode, currentFiles, summaryTextInput, useHierarchical, summaryFormat,
-    styleTarget, rewriteStyle, rewriteInstructions, rewriteLength,
-    reasoningPrompt, reasoningSettings, scaffolderPrompt, scaffolderSettings,
-    requestSplitterSpec, requestSplitterSettings, promptEnhancerSettings,
-    agentDesignerSettings, chatSettings
-  ]);
 
-  const handleChatSubmit = useCallback(async (e?: FormEvent<HTMLFormElement>) => {
-    e?.preventDefault();
-    if (!canSubmit) return;
-
-    const providerInfo = AI_PROVIDERS.find(provider => provider.id === aiProviderSettings.selectedProvider);
-    const apiKeyForProvider = aiProviderSettings.apiKeys?.[aiProviderSettings.selectedProvider];
-    if (providerInfo?.requiresApiKey && (!apiKeyForProvider || apiKeyForProvider.trim() === '')) {
-      setError({ message: `${providerInfo.label} requires an API key. Please add it in settings before starting a chat.` });
-      return;
-    }
-
-    const historyBeforeMessage = chatHistory;
-    const trimmedInput = chatInput.trim();
-
-    try {
-      const fileParts = chatFiles ? await Promise.all(chatFiles.map(fileToGenerativePart)) : [];
-      const textParts = trimmedInput ? [{ text: trimmedInput }] : [];
-      const userMessageParts = [...fileParts, ...textParts];
-
-      if (userMessageParts.length === 0) {
-        return;
-      }
-
-      const userMessage: ChatMessage = { role: 'user', parts: userMessageParts };
-
-      setChatHistory(prev => [...prev, userMessage, { role: 'model', parts: [{ text: '' }], thinking: [] }]);
-      setChatInput('');
-      setChatFiles(null);
-      setIsStreamingResponse(true);
-      setError(null);
-
-      const response = await sendChatMessage({
-        history: historyBeforeMessage,
-        userMessage: userMessageParts,
-        systemInstruction: chatSettings.systemInstruction,
-        vectorStoreSettings: chatSettings.vectorStore,
-      });
-
-      setChatHistory(prev => {
-        if (prev.length === 0) return prev;
-        const updatedHistory = [...prev];
-        const lastIndex = updatedHistory.length - 1;
-        const lastMessage = updatedHistory[lastIndex];
-        if (lastMessage && lastMessage.role === 'model') {
-          const thinkingSegments = response.thinking.length > 0 ? [...response.thinking] : undefined;
-          const finalText = response.text;
-          const firstPart = lastMessage.parts[0];
-
-          if (firstPart && 'text' in firstPart) {
-            firstPart.text = finalText;
-            lastMessage.thinking = thinkingSegments;
-          } else {
-            updatedHistory[lastIndex] = { role: 'model', parts: [{ text: finalText }], thinking: thinkingSegments };
-          }
+    submissionPromise
+      .finally(() => {
+        if (abortControllersRef.current[modeAtSubmission] === controller) {
+          delete abortControllersRef.current[modeAtSubmission];
         }
-        return updatedHistory;
+      })
+      .catch(() => {
+        // Errors are handled within handleSubmission
       });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError') {
-        setChatHistory(prev => (prev.length > 0 ? prev.slice(0, prev.length - 1) : prev));
-        return;
-      }
-      console.error('Chat error:', err);
-      const errorMessage = err instanceof Error ? err.message : 'An unknown error occurred.';
-      setError({ message: `Chat failed: ${errorMessage}` });
-      setChatHistory(prev => (prev.length > 0 ? prev.slice(0, prev.length - 1) : prev));
-    } finally {
-      setIsStreamingResponse(false);
-    }
-  }, [
+  }, [activeMode, chatSettings, getStateForMode, setModeValue]);
+
+  const handleChatSubmit = useChatSubmission({
+    activeMode,
     aiProviderSettings,
+    activeProviderInfo,
+    resolveProviderForMode,
+    chatSettings,
     canSubmit,
-    chatFiles,
-    chatHistory,
     chatInput,
-    chatSettings.systemInstruction,
-    chatSettings.vectorStore,
-  ]);
+    chatFiles,
+    getStateForMode,
+    setModeValue,
+  });
   
-    const handleSavePromptPreset = (name: string, prompt: string) => {
+  const handleSavePromptPreset = useCallback(
+    (name: string, prompt: string) => {
       setSavedPrompts(prev => {
         const existingIndex = prev.findIndex(p => p.name === name);
         if (existingIndex > -1) {
-          // Update existing
-          const newPrompts = [...prev];
-          newPrompts[existingIndex] = { name, prompt };
-          return newPrompts;
-        } else {
-          // Add new
-          return [...prev, { name, prompt }];
+          const updated = [...prev];
+          updated[existingIndex] = { name, prompt };
+          return updated;
         }
+        return [...prev, { name, prompt }];
       });
-    };
+    },
+    [setSavedPrompts],
+  );
 
-  const handleDeletePromptPreset = useCallback((name: string) => {
-    setSavedPrompts(prev => prev.filter(item => item.name !== name));
-  }, [setSavedPrompts]);
+  const handleDeletePromptPreset = useCallback(
+    (name: string) => {
+      setSavedPrompts(prev => prev.filter(item => item.name !== name));
+    },
+    [setSavedPrompts],
+  );
+
+  useEffect(() => {
+    if (appState === 'cancelled') {
+      handleReset();
+    }
+  }, [appState, handleReset]);
 
   const handleFileSelect = useCallback(
     (files: File[]) => {
@@ -545,10 +316,14 @@ const App: React.FC = () => {
 
   const handleModeChange = useCallback(
     (mode: Mode) => {
-      setActiveMode(prev => (prev === mode ? prev : mode));
+      if (mode === activeMode) {
+        return;
+      }
+      handleReset(mode);
+      setActiveMode(mode);
       setIsReportModalOpen(false);
     },
-    [],
+    [activeMode, handleReset],
   );
 
   const handleWidthSliderChange = useCallback(
@@ -580,7 +355,7 @@ const App: React.FC = () => {
     onChatFilesChange: (value: File[] | null) => setModeValue('chatFiles', value),
     onSubmit: handleChatSubmit,
     canSubmit,
-    onOpenSettings: () => setIsChatSettingsModalOpen(true),
+    onOpenSettings: () => setIsSettingsModalOpen(true),
   }), [
     chatHistory,
     isStreamingResponse,
@@ -609,6 +384,7 @@ const App: React.FC = () => {
 
   return (
     <>
+      <MenuBar onOpenSettings={() => setIsSettingsModalOpen(true)} />
       <div className="min-h-screen bg-transparent flex flex-col items-center justify-center p-4 sm:p-8 transition-all duration-300">
         <div className={`w-full ${activeMode === 'chat' ? 'max-w-6xl' : 'max-w-3xl'} bg-surface shadow-2xl rounded-lg ${activeMode === 'chat' ? 'px-6 sm:px-10 pt-6 sm:pt-10 pb-2 sm:pb-3' : 'p-6 sm:p-10'} border border-border-color animate-breathing-glow transition-all duration-500 ease-in-out`}>
           <header className="mb-6 text-center">
@@ -621,10 +397,11 @@ const App: React.FC = () => {
           </header>
 
           <div className="mb-6">
-            <Tabs tabs={TABS} activeTabId={activeMode} onTabChange={(id) => {
-              setActiveMode(id as Mode);
-              handleReset();
-            }} />
+            <Tabs
+              tabs={TABS}
+              activeTabId={activeMode}
+              onTabChange={id => handleModeChange(id as Mode)}
+            />
           </div>
 
           <div className="mb-6 bg-secondary/60 border border-border-color rounded-lg px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm">
@@ -639,56 +416,17 @@ const App: React.FC = () => {
                 <span className="font-medium text-text-primary">{activeModelName || 'Select a model'}</span>
               </div>
             </div>
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 text-xs sm:text-sm">
-              <span className={`font-medium ${providerStatusTone}`}>{providerStatusText}</span>
-              <button
-                type="button"
-                onClick={() => setIsChatSettingsModalOpen(true)}
-                className="px-4 py-2 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary-hover transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
-              >
-                Manage AI Settings
-              </button>
-            </div>
+            <span className={`font-medium ${providerStatusTone}`}>{providerStatusText}</span>
           </div>
 
           {activeMode === 'chat' ? (
-              <ChatInterface
-                history={chatHistory}
-                isStreaming={isStreamingResponse}
-                chatInput={chatInput}
-                onChatInputChange={setChatInput}
-                chatFiles={chatFiles}
-                onChatFilesChange={setChatFiles}
-                onSubmit={handleChatSubmit}
-                canSubmit={canSubmit}
-                onOpenSettings={() => setIsChatSettingsModalOpen(true)}
-              />
-          ) : (appState === 'idle' || appState === 'fileSelected') && (
-            <MainForm 
-              activeMode={activeMode}
-              currentFiles={currentFiles}
-              summaryFormat={summaryFormat} onSummaryFormatChange={setSummaryFormat}
-              summarySearchTerm={summarySearchTerm} onSummarySearchTermChange={setSummarySearchTerm}
-              summaryTextInput={summaryTextInput} onSummaryTextChange={handleSummaryTextChange}
-              useHierarchical={useHierarchical} onUseHierarchicalChange={setUseHierarchical}
-              styleTarget={styleTarget} onStyleTargetChange={setStyleTarget}
-              rewriteStyle={rewriteStyle} onRewriteStyleChange={setRewriteStyle}
-              rewriteInstructions={rewriteInstructions} onRewriteInstructionsChange={setRewriteInstructions}
-              rewriteLength={rewriteLength} onRewriteLengthChange={setRewriteLength}
-              reasoningPrompt={reasoningPrompt} onReasoningPromptChange={setReasoningPrompt}
-              reasoningSettings={reasoningSettings} onReasoningSettingsChange={setReasoningSettings}
-              scaffolderPrompt={scaffolderPrompt} onScaffolderPromptChange={setScaffolderPrompt}
-              scaffolderSettings={scaffolderSettings} onScaffolderSettingsChange={setScaffolderSettings}
-              requestSplitterSpec={requestSplitterSpec} onRequestSplitterSpecChange={setRequestSplitterSpec}
-              requestSplitterSettings={requestSplitterSettings} onRequestSplitterSettingsChange={setRequestSplitterSettings}
-              promptEnhancerSettings={promptEnhancerSettings} onPromptEnhancerSettingsChange={setPromptEnhancerSettings}
-              agentDesignerSettings={agentDesignerSettings} onAgentDesignerSettingsChange={setAgentDesignerSettings}
-              onFileSelect={handleFileSelect}
-            />
+            <ChatInterface {...chatInterfaceProps} />
+          ) : (
+            showMainForm && <MainForm {...mainFormProps} />
           )}
 
-          {activeMode !== 'chat' && canSubmit && appState !== 'completed' && appState !== 'error' && (
-            <SubmitButton 
+          {showSubmitButton && (
+            <SubmitButton
               onClick={handleSubmit}
               disabled={appState === 'processing'}
               appState={appState}
@@ -702,28 +440,30 @@ const App: React.FC = () => {
               <StopButton onClick={handleStop} />
             </div>
           )}
-          
-          {appState === 'completed' && processedData && (
-            <ResultsViewer 
-              processedData={processedData}
-              activeMode={activeMode}
-              scaffolderSettings={scaffolderSettings}
-              onReset={handleReset}
-              onOpenReportModal={() => setIsReportModalOpen(true)}
-              onDownloadReasoning={(type) => downloadReasoningArtifact(processedData, type)}
-              onDownloadScaffold={(type) => downloadScaffoldArtifact(processedData, scaffolderSettings, type)}
-              onDownloadRequestSplitter={(type) => downloadRequestSplitterArtifact(processedData, type)}
-              onDownloadPromptEnhancer={(type) => downloadPromptEnhancerArtifact(processedData, type)}
-              onDownloadAgentDesigner={(type) => downloadAgentDesignerArtifact(processedData, type)}
-            />
-          )}
 
-          {appState === 'error' && error && <div className="mt-8 p-4 bg-red-900 border border-red-700 rounded-lg text-red-100 animate-fade-in-scale" role="alert">
-            <div className="flex items-center mb-2"><XCircleIcon className="w-6 h-6 mr-2" aria-hidden="true" /><h3 className="text-lg font-semibold">Error</h3></div>
-            <p className="text-sm">{error.message}</p>
-            {error.details && <details className="mt-2 text-xs"><summary>Show Details</summary><pre className="whitespace-pre-wrap break-all bg-red-800 p-2 rounded mt-1">{error.details}</pre></details>}
-            <button onClick={handleReset} className="mt-4 w-full px-6 py-2 bg-red-700 text-white font-semibold rounded-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-surface">Try Again</button>
-          </div>}
+          {showResults && resultsViewerProps && <ResultsViewer {...resultsViewerProps} />}
+
+          {showError && error && (
+            <div className="mt-8 p-4 bg-red-900 border border-red-700 rounded-lg text-red-100 animate-fade-in-scale" role="alert">
+              <div className="flex items-center mb-2">
+                <XCircleIcon className="w-6 h-6 mr-2" aria-hidden="true" />
+                <h3 className="text-lg font-semibold">Error</h3>
+              </div>
+              <p className="text-sm">{error.message}</p>
+              {error.details && (
+                <details className="mt-2 text-xs">
+                  <summary>Show Details</summary>
+                  <pre className="whitespace-pre-wrap break-all bg-red-800 p-2 rounded mt-1">{error.details}</pre>
+                </details>
+              )}
+              <button
+                onClick={() => handleReset()}
+                className="mt-4 w-full px-6 py-2 bg-red-700 text-white font-semibold rounded-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-surface"
+              >
+                Try Again
+              </button>
+            </div>
+          )}
         </div>
         <footer className="text-center mt-8 text-text-secondary text-xs">
           <p>&copy; {new Date().getFullYear()} AI Content Suite. Powered by {providerSummaryText}.</p>
@@ -738,16 +478,16 @@ const App: React.FC = () => {
         styleTarget={activeMode === 'styleExtractor' ? styleTarget : undefined}
         nextStepSuggestions={nextStepSuggestions}
       />
-      <ChatSettingsModal
-        isOpen={isChatSettingsModalOpen}
-        onClose={() => setIsChatSettingsModalOpen(false)}
+      <SettingsModal
+        isOpen={isSettingsModalOpen}
+        onClose={() => setIsSettingsModalOpen(false)}
         currentSettings={chatSettings}
         providerSettings={aiProviderSettings}
         providers={AI_PROVIDERS}
         onSave={(newSettings, newProviderSettings) => {
           setChatSettings(newSettings);
           setAiProviderSettings(newProviderSettings);
-          setIsChatSettingsModalOpen(false);
+          setIsSettingsModalOpen(false);
         }}
         onFetchModels={fetchModelsForProvider}
         savedPrompts={savedPrompts}

--- a/components/layouts/MenuBar.tsx
+++ b/components/layouts/MenuBar.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface MenuBarProps {
+  onOpenSettings: () => void;
+}
+
+export const MenuBar: React.FC<MenuBarProps> = ({ onOpenSettings }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const handleToggle = () => setIsOpen(prev => !prev);
+
+  const handleSettingsClick = () => {
+    onOpenSettings();
+    setIsOpen(false);
+  };
+
+  return (
+    <nav className="sticky top-0 z-40 w-full border-b border-border-color bg-surface/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-secondary">
+          AI Content Suite
+        </span>
+        <div className="relative" ref={dropdownRef}>
+          <button
+            type="button"
+            onClick={handleToggle}
+            className="inline-flex items-center gap-2 rounded-md bg-secondary px-3 py-1.5 text-sm font-semibold text-text-primary shadow-sm transition-colors duration-150 hover:bg-secondary/80 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-surface"
+            aria-haspopup="true"
+            aria-expanded={isOpen}
+          >
+            Settings
+            <span className={`transition-transform duration-150 ${isOpen ? 'rotate-180' : 'rotate-0'}`} aria-hidden="true">
+              ▾
+            </span>
+          </button>
+          {isOpen && (
+            <div className="absolute right-0 mt-2 w-56 overflow-hidden rounded-md border border-border-color bg-surface shadow-xl">
+              <button
+                type="button"
+                onClick={handleSettingsClick}
+                className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-text-primary hover:bg-secondary focus:outline-none focus:bg-secondary"
+              >
+                Workspace preferences
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+};

--- a/components/modals/SettingsModal.tsx
+++ b/components/modals/SettingsModal.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState, useEffect, useCallback, useRef, MouseEvent } from 'react';
 import type {
   ChatSettings,
@@ -8,6 +7,8 @@ import type {
   ModelOption,
   VectorStoreSettings,
   EmbeddingProviderId,
+  FeatureModelPreferences,
+  Mode,
 } from '../../types';
 import type { ProviderInfo, EmbeddingProviderInfo } from '../../services/providerRegistry';
 import {
@@ -20,10 +21,12 @@ import {
   requiresEmbeddingApiKey,
   getEmbeddingProviderDefaultEndpoint,
 } from '../../services/providerRegistry';
+import { MODE_IDS, TABS } from '../../constants/uiConstants';
+import { sanitizeFeatureModelPreferences } from '../../utils/providerSettings';
 import { XCircleIcon } from '../icons/XCircleIcon';
 import { TrashIcon } from '../icons/TrashIcon';
 
-interface ChatSettingsModalProps {
+interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
   currentSettings: ChatSettings;
@@ -53,7 +56,15 @@ const withDefaults = (settings: ChatSettings): ChatSettings => ({
   vectorStore: ensureVectorStoreSettings(settings.vectorStore),
 });
 
-export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
+const MODE_LABEL_MAP: Record<Mode, string> = TABS.reduce((acc, tab) => {
+  acc[tab.id as Mode] = tab.label;
+  return acc;
+}, {} as Record<Mode, string>);
+
+const featurePreferenceCount = (preferences?: FeatureModelPreferences): number =>
+  preferences ? Object.keys(preferences).length : 0;
+
+export const SettingsModal: React.FC<SettingsModalProps> = ({
   isOpen,
   onClose,
   currentSettings,
@@ -65,13 +76,12 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
   onSavePreset,
   onDeletePreset,
 }) => {
-
   const [editedSettings, setEditedSettings] = useState<ChatSettings>(() => withDefaults(currentSettings));
   const [editedProviderSettings, setEditedProviderSettings] = useState<AIProviderSettings>(providerSettings);
   const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
-  const [selectedPreset, setSelectedPreset] = useState<string>(''); // Holds the name of the selected preset
+  const [selectedPreset, setSelectedPreset] = useState<string>('');
   const loadRequestIdRef = useRef(0);
 
   const updateVectorStore = useCallback((updater: (prev: VectorStoreSettings) => VectorStoreSettings) => {
@@ -80,6 +90,46 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
       return {
         ...prev,
         vectorStore: updater(currentVector),
+      };
+    });
+  }, []);
+
+  const enableFeatureOverride = useCallback((mode: Mode, enabled: boolean) => {
+    setEditedProviderSettings(prev => {
+      const nextPreferences: FeatureModelPreferences = { ...(prev.featureModelPreferences ?? {}) };
+      if (enabled) {
+        const globalModel = prev.selectedModel?.trim() || DEFAULT_PROVIDER_MODELS[prev.selectedProvider] || '';
+        nextPreferences[mode] = {
+          provider: prev.selectedProvider,
+          model: globalModel,
+        };
+      } else {
+        delete nextPreferences[mode];
+      }
+
+      return {
+        ...prev,
+        featureModelPreferences: featurePreferenceCount(nextPreferences) > 0 ? nextPreferences : undefined,
+      };
+    });
+  }, []);
+
+  const updateFeaturePreference = useCallback((mode: Mode, updater: (prev: { provider: AIProviderId; model: string }) => {
+    provider: AIProviderId;
+    model: string;
+  }) => {
+    setEditedProviderSettings(prev => {
+      const existing = prev.featureModelPreferences?.[mode] ?? {
+        provider: prev.selectedProvider,
+        model: prev.selectedModel?.trim() || DEFAULT_PROVIDER_MODELS[prev.selectedProvider] || '',
+      };
+      const nextPreferences: FeatureModelPreferences = {
+        ...(prev.featureModelPreferences ?? {}),
+        [mode]: updater(existing),
+      };
+      return {
+        ...prev,
+        featureModelPreferences: nextPreferences,
       };
     });
   }, []);
@@ -136,7 +186,7 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
       setModelOptions([]);
       setModelsError(null);
       setModelsLoading(false);
-      setSelectedPreset(''); // Reset selection when opening
+      setSelectedPreset('');
     }
   }, [isOpen, currentSettings, providerSettings]);
 
@@ -153,9 +203,9 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
     const trimmedModel = editedProviderSettings.selectedModel.trim();
     const fallbackModel = DEFAULT_PROVIDER_MODELS[providerId] ?? DEFAULT_PROVIDER_MODELS[providerSettings.selectedProvider];
     const sanitizedApiKeys = Object.entries(editedProviderSettings.apiKeys || {}).reduce<AIProviderSettings['apiKeys']>((acc, [key, value]) => {
-      const trimmed = typeof value === 'string' ? value.trim() : value;
+      const trimmed = typeof value === 'string' ? value.trim() : '';
       if (trimmed) {
-        acc[key] = trimmed;
+        acc[key as AIProviderId] = trimmed;
       }
       return acc;
     }, {});
@@ -166,7 +216,8 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
     const sanitizedVectorStore: VectorStoreSettings = {
       enabled: Boolean(draftVectorStore.enabled),
       url: (draftVectorStore.url || '').trim(),
-      apiKey: draftVectorStore.apiKey && draftVectorStore.apiKey.trim() !== '' ? draftVectorStore.apiKey.trim() : undefined,
+      apiKey:
+        draftVectorStore.apiKey && draftVectorStore.apiKey.trim() !== '' ? draftVectorStore.apiKey.trim() : undefined,
       collection: (draftVectorStore.collection || '').trim(),
       topK: sanitizedTopK,
       embedding: {
@@ -182,10 +233,19 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
             : undefined,
       },
     };
+
+    const sanitizedFeaturePreferences = sanitizeFeatureModelPreferences(
+      editedProviderSettings.featureModelPreferences,
+    );
+    const finalFeaturePreferences = featurePreferenceCount(sanitizedFeaturePreferences) > 0
+      ? sanitizedFeaturePreferences
+      : undefined;
+
     const finalProviderSettings: AIProviderSettings = {
       selectedProvider: providerId,
       selectedModel: trimmedModel || fallbackModel,
       apiKeys: sanitizedApiKeys,
+      featureModelPreferences: finalFeaturePreferences,
     };
 
     const finalChatSettings: ChatSettings = {
@@ -298,27 +358,28 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
   };
 
   const handleSaveAsPreset = () => {
-    const name = window.prompt("Enter a name for this preset:", selectedPreset || "New Preset");
+    const name = window.prompt('Enter a name for this preset:', selectedPreset || 'New Preset');
     if (name && name.trim() !== '') {
       onSavePreset(name.trim(), editedSettings.systemInstruction);
-      setSelectedPreset(name.trim()); // Select the new/updated preset
+      setSelectedPreset(name.trim());
     }
   };
 
   const handleDeletePreset = () => {
     if (selectedPreset && window.confirm(`Are you sure you want to delete the preset "${selectedPreset}"?`)) {
       onDeletePreset(selectedPreset);
-      setSelectedPreset(''); // Deselect after deletion
+      setSelectedPreset('');
     }
   };
 
   const handleOverlayClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
-        onClose();
+      onClose();
     }
   };
 
   const selectedProviderInfo = providers.find(p => p.id === editedProviderSettings.selectedProvider);
+  const globalProviderLabel = selectedProviderInfo?.label ?? 'Selected provider';
   const selectedApiKey = editedProviderSettings.apiKeys?.[editedProviderSettings.selectedProvider] ?? '';
   const vectorStoreSettings = editedSettings.vectorStore ?? ensureVectorStoreSettings();
   const embeddingSettings = vectorStoreSettings.embedding;
@@ -330,106 +391,238 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
       ? 'https://your-embedding-endpoint/v1/embeddings'
       : getEmbeddingProviderDefaultEndpoint(embeddingSettings.provider) ?? '';
   const embeddingRequiresApiKey = requiresEmbeddingApiKey(embeddingSettings.provider);
+  const featurePreferences = editedProviderSettings.featureModelPreferences ?? {};
+  const globalModelName = editedProviderSettings.selectedModel?.trim() || DEFAULT_PROVIDER_MODELS[editedProviderSettings.selectedProvider] || '';
 
   if (!isOpen) return null;
 
   return (
-    <div 
-        className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50 transition-opacity duration-300 animate-fade-in-scale"
-        onClick={handleOverlayClick}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="modal-title"
+    <div
+      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50 transition-opacity duration-300 animate-fade-in-scale"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="workspace-settings-modal"
     >
-      <div className="bg-surface rounded-xl shadow-2xl w-full max-w-lg transform transition-all duration-300">
-        <header className="flex items-center justify-between p-4 sm:p-5 border-b border-border-color">
-          <h2 id="modal-title" className="text-lg sm:text-xl font-semibold text-text-primary">Chat Settings</h2>
-          <button onClick={onClose} className="text-text-secondary hover:text-text-primary transition-colors" aria-label="Close modal">
+      <div className="bg-surface rounded-xl shadow-2xl w-full max-w-4xl transform transition-all duration-300">
+        <header className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-6 border-b border-border-color">
+          <div>
+            <h2 id="workspace-settings-modal" className="text-xl font-semibold text-text-primary">
+              Workspace Settings
+            </h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              Configure global AI providers, per-feature overrides, and retrieval settings for your team.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="self-start text-text-secondary hover:text-text-primary transition-colors"
+            aria-label="Close settings"
+          >
             <XCircleIcon className="w-7 h-7" />
           </button>
         </header>
-        
-        <div className="p-6 sm:p-8 space-y-4">
-            <div>
-              <label htmlFor="provider-selector" className="block text-sm font-medium text-text-secondary mb-2">
-                AI Provider
-              </label>
-              <select
-                id="provider-selector"
-                value={editedProviderSettings.selectedProvider}
-                onChange={(e) => handleProviderChange(e.target.value as AIProviderId)}
-                className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
-              >
-                {providers.map(provider => (
-                  <option key={provider.id} value={provider.id}>{provider.label}</option>
-                ))}
-              </select>
-              {selectedProviderInfo?.docsUrl && (
-                <p className="mt-1 text-xs text-text-secondary">
-                  API docs:{' '}
-                  <a href={selectedProviderInfo.docsUrl} target="_blank" rel="noreferrer" className="text-primary underline">
-                    {selectedProviderInfo.docsUrl}
-                  </a>
-                </p>
-              )}
-            </div>
 
+        <div className="p-6 sm:p-8 space-y-8 max-h-[80vh] overflow-y-auto">
+          <section className="space-y-4">
             <div>
-              <label htmlFor="provider-api-key" className="block text-sm font-medium text-text-secondary mb-2">
-                API Key
-              </label>
-              <input
-                id="provider-api-key"
-                type="password"
-                value={selectedApiKey}
-                onChange={(e) => handleApiKeyChange(editedProviderSettings.selectedProvider, e.target.value)}
-                placeholder={selectedProviderInfo?.requiresApiKey ? 'Enter your API key' : 'Optional for this provider'}
-                className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
-              />
-              <p className="mt-1 text-xs text-text-secondary">
-                {selectedProviderInfo?.requiresApiKey
-                  ? 'Required to authenticate requests.'
-                  : 'Optional. Leave blank for local deployments.'}
+              <h3 className="text-base font-semibold text-text-primary">Global Provider</h3>
+              <p className="text-sm text-text-secondary">
+                Select the default provider, model, and API key the suite should use when a feature does not have a custom override.
               </p>
             </div>
-
-            <div>
-              <label htmlFor="provider-model" className="block text-sm font-medium text-text-secondary mb-2">
-                Model
-              </label>
-              <div className="flex items-center gap-2">
-                <input
-                  id="provider-model"
-                  type="text"
-                  list="provider-model-options"
-                  value={editedProviderSettings.selectedModel}
-                  onChange={(e) => handleModelInputChange(e.target.value)}
-                  placeholder="Select or enter a model name"
-                  className="flex-grow px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
-                />
-                <button
-                  type="button"
-                  onClick={() => loadModels(editedProviderSettings.selectedProvider, selectedApiKey)}
-                  className="px-3 py-2 bg-muted text-text-primary font-medium rounded-md hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary disabled:opacity-50"
-                  disabled={modelsLoading}
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <label htmlFor="provider-selector" className="block text-sm font-medium text-text-secondary mb-2">
+                  AI provider
+                </label>
+                <select
+                  id="provider-selector"
+                  value={editedProviderSettings.selectedProvider}
+                  onChange={(e) => handleProviderChange(e.target.value as AIProviderId)}
+                  className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
                 >
-                  {modelsLoading ? 'Loading...' : 'Refresh'}
-                </button>
+                  {providers.map(provider => (
+                    <option key={provider.id} value={provider.id}>{provider.label}</option>
+                  ))}
+                </select>
+                {selectedProviderInfo?.docsUrl && (
+                  <p className="mt-1 text-xs text-text-secondary">
+                    API docs:{' '}
+                    <a href={selectedProviderInfo.docsUrl} target="_blank" rel="noreferrer" className="text-primary underline">
+                      {selectedProviderInfo.docsUrl}
+                    </a>
+                  </p>
+                )}
               </div>
-              <datalist id="provider-model-options">
-                {modelOptions.map(model => (
-                  <option key={model.id} value={model.id}>{model.label}</option>
-                ))}
-              </datalist>
-              {modelsError ? (
-                <p className="mt-1 text-xs text-destructive">{modelsError}</p>
-              ) : modelOptions.length > 0 ? (
-                <p className="mt-1 text-xs text-text-secondary">Choose a model from the suggestions or provide a custom value.</p>
-              ) : (
-                <p className="mt-1 text-xs text-text-secondary">Enter a model name or refresh to fetch available options.</p>
-              )}
-            </div>
 
+              <div>
+                <label htmlFor="provider-api-key" className="block text-sm font-medium text-text-secondary mb-2">
+                  API key
+                </label>
+                <input
+                  id="provider-api-key"
+                  type="password"
+                  value={selectedApiKey}
+                  onChange={(e) => handleApiKeyChange(editedProviderSettings.selectedProvider, e.target.value)}
+                  placeholder={selectedProviderInfo?.requiresApiKey ? 'Enter your API key' : 'Optional for this provider'}
+                  className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                />
+                <p className="mt-1 text-xs text-text-secondary">
+                  {selectedProviderInfo?.requiresApiKey
+                    ? 'Required to authenticate requests.'
+                    : 'Optional. Leave blank for local deployments.'}
+                </p>
+              </div>
+
+              <div>
+                <label htmlFor="provider-model" className="block text-sm font-medium text-text-secondary mb-2">
+                  Model
+                </label>
+                <div className="flex items-center gap-2">
+                  <input
+                    id="provider-model"
+                    type="text"
+                    list="provider-model-options"
+                    value={editedProviderSettings.selectedModel}
+                    onChange={(e) => handleModelInputChange(e.target.value)}
+                    placeholder="Select or enter a model name"
+                    className="flex-grow px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => loadModels(editedProviderSettings.selectedProvider, selectedApiKey)}
+                    className="px-3 py-2 bg-muted text-text-primary font-medium rounded-md hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary disabled:opacity-50"
+                    disabled={modelsLoading}
+                  >
+                    {modelsLoading ? 'Loading…' : 'Refresh'}
+                  </button>
+                </div>
+                <datalist id="provider-model-options">
+                  {modelOptions.map(model => (
+                    <option key={model.id} value={model.id}>{model.label}</option>
+                  ))}
+                </datalist>
+                {modelsError ? (
+                  <p className="mt-1 text-xs text-destructive">{modelsError}</p>
+                ) : modelOptions.length > 0 ? (
+                  <p className="mt-1 text-xs text-text-secondary">Choose a model from the suggestions or provide a custom value.</p>
+                ) : (
+                  <p className="mt-1 text-xs text-text-secondary">Enter a model name or refresh to fetch available options.</p>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-base font-semibold text-text-primary">Per-feature overrides</h3>
+              <p className="text-sm text-text-secondary">
+                Enable custom providers and models for individual workflows. When disabled the feature uses the global configuration ({globalProviderLabel} • {globalModelName || 'model auto-selection'}).
+              </p>
+            </div>
+            <div className="space-y-4">
+              {MODE_IDS.map(mode => {
+                const preference = featurePreferences[mode];
+                const overrideEnabled = Boolean(preference);
+                const providerValue = preference?.provider ?? editedProviderSettings.selectedProvider;
+                const modelValue = preference?.model ?? '';
+                const providerInfo = providers.find(p => p.id === providerValue);
+                return (
+                  <div key={mode} className="border border-border-color rounded-lg p-4 space-y-4">
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                      <div>
+                        <h4 className="text-sm font-semibold text-text-primary">{MODE_LABEL_MAP[mode]}</h4>
+                        <p className="text-xs text-text-secondary">
+                          {overrideEnabled
+                            ? 'Requests for this feature will always use the provider defined below.'
+                            : 'Using the global provider and model until a custom override is enabled.'}
+                        </p>
+                      </div>
+                      <label className="inline-flex items-center gap-2 text-xs text-text-secondary">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 text-primary focus:ring-ring border-border-color rounded"
+                          checked={overrideEnabled}
+                          onChange={(event) => enableFeatureOverride(mode, event.target.checked)}
+                        />
+                        Custom settings
+                      </label>
+                    </div>
+
+                    <div className="grid gap-4 sm:grid-cols-2">
+                      <div>
+                        <label className="block text-xs font-medium text-text-secondary mb-2">
+                          Provider
+                        </label>
+                        <select
+                          value={providerValue}
+                          onChange={(e) => updateFeaturePreference(mode, prev => ({
+                            provider: e.target.value as AIProviderId,
+                            model:
+                              prev.provider === (e.target.value as AIProviderId)
+                                ? prev.model
+                                : DEFAULT_PROVIDER_MODELS[e.target.value as AIProviderId] ?? prev.model,
+                          }))}
+                          className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary text-sm"
+                          disabled={!overrideEnabled}
+                        >
+                          {providers.map(provider => (
+                            <option key={provider.id} value={provider.id}>{provider.label}</option>
+                          ))}
+                        </select>
+                        <p className="mt-1 text-[11px] text-text-secondary">
+                          {providerInfo?.requiresApiKey
+                            ? 'Ensure an API key is stored for this provider.'
+                            : 'Local providers can be used without an API key.'}
+                        </p>
+                      </div>
+
+                      <div>
+                        <label className="block text-xs font-medium text-text-secondary mb-2">
+                          Preferred model
+                        </label>
+                        <input
+                          type="text"
+                          value={modelValue}
+                          onChange={(e) => updateFeaturePreference(mode, prev => ({
+                            provider: prev.provider,
+                            model: e.target.value,
+                          }))}
+                          placeholder="Leave blank to use the provider default"
+                          className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                          disabled={!overrideEnabled}
+                        />
+                        <p className="mt-1 text-[11px] text-text-secondary">
+                          Will fall back to {DEFAULT_PROVIDER_MODELS[providerValue] ?? 'the provider default'} when blank.
+                        </p>
+                      </div>
+                    </div>
+
+                    {overrideEnabled && (
+                      <div className="text-right">
+                        <button
+                          type="button"
+                          onClick={() => enableFeatureOverride(mode, false)}
+                          className="text-xs font-medium text-primary hover:text-primary-hover"
+                        >
+                          Reset to global defaults
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div>
+              <h3 className="text-base font-semibold text-text-primary">Vector store & embeddings</h3>
+              <p className="text-sm text-text-secondary">
+                Connect a Qdrant cluster and embedding provider to enrich chat conversations with contextual memory.
+              </p>
+            </div>
             <div className="border border-border-color rounded-lg p-4 space-y-4">
               <div className="flex items-start gap-3">
                 <input
@@ -514,9 +707,7 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
                     disabled={!vectorStoreSettings.enabled}
                   />
                 </div>
-              </div>
 
-              <div className="grid gap-4 sm:grid-cols-2">
                 <div>
                   <label htmlFor="embedding-provider" className="block text-sm font-medium text-text-secondary mb-2">
                     Embedding provider
@@ -529,24 +720,9 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
                     disabled={!vectorStoreSettings.enabled}
                   >
                     {EMBEDDING_PROVIDERS.map(provider => (
-                      <option key={provider.id} value={provider.id}>
-                        {provider.label}
-                      </option>
+                      <option key={provider.id} value={provider.id}>{provider.label}</option>
                     ))}
                   </select>
-                  {selectedEmbeddingProviderInfo?.docsUrl && (
-                    <p className="mt-1 text-xs text-text-secondary">
-                      API docs:{' '}
-                      <a
-                        href={selectedEmbeddingProviderInfo.docsUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-primary underline"
-                      >
-                        {selectedEmbeddingProviderInfo.docsUrl}
-                      </a>
-                    </p>
-                  )}
                 </div>
 
                 <div>
@@ -593,7 +769,7 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
                     type="url"
                     value={embeddingSettings.baseUrl ?? ''}
                     onChange={(e) => handleEmbeddingBaseUrlChange(e.target.value)}
-                    placeholder={embeddingEndpointPlaceholder || 'https://...' }
+                    placeholder={embeddingEndpointPlaceholder || 'https://…'}
                     className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
                     disabled={!vectorStoreSettings.enabled}
                   />
@@ -604,76 +780,87 @@ export const ChatSettingsModal: React.FC<ChatSettingsModalProps> = ({
                 </div>
               </div>
             </div>
-            <div>
-              <label htmlFor="preset-selector" className="block text-sm font-medium text-text-secondary mb-2">
-                Manage Presets
-              </label>
-              <div className="flex items-center gap-2">
-                <select
-                  id="preset-selector"
-                  value={selectedPreset}
-                  onChange={(e) => handleLoadPreset(e.target.value)}
-                  className="flex-grow w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
-                >
-                  <option value="">-- Load a preset --</option>
-                  {savedPrompts.map(p => (
-                    <option key={p.name} value={p.name}>{p.name}</option>
-                  ))}
-                </select>
-                <button
-                  onClick={handleDeletePreset}
-                  disabled={!selectedPreset}
-                  className="p-2 bg-destructive/80 text-destructive-foreground rounded-md hover:bg-destructive disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  aria-label="Delete selected preset"
-                >
-                  <TrashIcon className="w-5 h-5" />
-                </button>
-              </div>
-            </div>
+          </section>
 
+          <section className="space-y-4">
             <div>
+              <h3 className="text-base font-semibold text-text-primary">Chat behaviour</h3>
+              <p className="text-sm text-text-secondary">
+                Manage reusable system prompts and presets for the conversational workspace.
+              </p>
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="preset-selector" className="block text-sm font-medium text-text-secondary mb-2">
+                  Manage presets
+                </label>
+                <div className="flex items-center gap-2">
+                  <select
+                    id="preset-selector"
+                    value={selectedPreset}
+                    onChange={(e) => handleLoadPreset(e.target.value)}
+                    className="flex-grow w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                  >
+                    <option value="">-- Load a preset --</option>
+                    {savedPrompts.map(p => (
+                      <option key={p.name} value={p.name}>{p.name}</option>
+                    ))}
+                  </select>
+                  <button
+                    onClick={handleDeletePreset}
+                    disabled={!selectedPreset}
+                    className="p-2 bg-destructive/80 text-destructive-foreground rounded-md hover:bg-destructive disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                    aria-label="Delete selected preset"
+                  >
+                    <TrashIcon className="w-5 h-5" />
+                  </button>
+                </div>
+              </div>
+
+              <div>
                 <label htmlFor="system-instruction-modal" className="block text-sm font-medium text-text-secondary mb-2">
-                    System Prompt
+                  System prompt
                 </label>
                 <textarea
-                    id="system-instruction-modal"
-                    rows={8}
-                    value={editedSettings.systemInstruction}
-                    onChange={(e) => {
-                        setEditedSettings({ ...editedSettings, systemInstruction: e.target.value });
-                        // If user edits, it's no longer a pristine preset
-                        if (selectedPreset) setSelectedPreset('');
-                    }}
-                    placeholder="Define the AI's persona and instructions..."
-                    className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
+                  id="system-instruction-modal"
+                  rows={8}
+                  value={editedSettings.systemInstruction}
+                  onChange={(e) => {
+                    setEditedSettings({ ...editedSettings, systemInstruction: e.target.value });
+                    if (selectedPreset) setSelectedPreset('');
+                  }}
+                  placeholder="Define the AI's persona and instructions..."
+                  className="w-full px-3 py-2 bg-input border border-border-color rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-ring text-text-primary placeholder-text-secondary text-sm"
                 />
-                 <p className="mt-2 text-xs text-text-secondary">
-                    Changes to the system prompt will start a new chat session to take effect.
+                <p className="mt-2 text-xs text-text-secondary">
+                  Changes to the system prompt will start a new chat session to take effect.
                 </p>
+              </div>
             </div>
+          </section>
         </div>
 
-        <footer className="flex items-center justify-between gap-4 p-4 bg-secondary rounded-b-xl">
+        <footer className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 p-4 bg-secondary rounded-b-xl">
+          <button
+            onClick={handleSaveAsPreset}
+            className="px-4 py-2 bg-muted text-text-primary font-semibold rounded-lg hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
+          >
+            Save as preset
+          </button>
+          <div className="flex items-center gap-3">
             <button
-                onClick={handleSaveAsPreset}
-                className="px-4 py-2 bg-muted text-text-primary font-semibold rounded-lg hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
+              onClick={onClose}
+              className="px-4 py-2 bg-muted text-text-primary font-semibold rounded-lg hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
             >
-                Save as Preset
+              Cancel
             </button>
-            <div className="flex items-center gap-4">
-              <button
-                  onClick={onClose}
-                  className="px-4 py-2 bg-muted text-text-primary font-semibold rounded-lg hover:bg-border-color transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
-              >
-                  Cancel
-              </button>
-              <button
-                  onClick={handleSave}
-                  className="px-6 py-2 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary-hover transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
-              >
-                  Save &amp; Close
-              </button>
-            </div>
+            <button
+              onClick={handleSave}
+              className="px-6 py-2 bg-primary text-primary-foreground font-semibold rounded-lg hover:bg-primary-hover transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-secondary"
+            >
+              Save &amp; close
+            </button>
+          </div>
         </footer>
       </div>
     </div>

--- a/components/views/controls/AgentDesignerControls.tsx
+++ b/components/views/controls/AgentDesignerControls.tsx
@@ -12,7 +12,7 @@ const Label: React.FC<{ htmlFor: string; children: React.ReactNode; className?: 
 );
 
 export const AgentDesignerControls: React.FC<AgentDesignerControlsProps> = ({ settings, onSettingsChange }) => {
-    
+
     const handleSettingChange = <K extends keyof AgentDesignerSettings>(key: K, value: AgentDesignerSettings[K]) => {
         onSettingsChange({ ...settings, [key]: value });
     };
@@ -23,6 +23,8 @@ export const AgentDesignerControls: React.FC<AgentDesignerControlsProps> = ({ se
             capabilities: { ...settings.capabilities, [key]: value }
         });
     };
+
+    type CapabilityKey = keyof AgentDesignerSettings['capabilities'];
 
     return (
         <div className="animate-fade-in-scale space-y-6">
@@ -87,19 +89,18 @@ export const AgentDesignerControls: React.FC<AgentDesignerControlsProps> = ({ se
             <fieldset>
                 <legend className="block text-xs font-medium text-text-secondary mb-2">Core Capabilities (Tools)</legend>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-x-4 gap-y-2 bg-secondary p-3 rounded-lg">
-                    {Object.keys(settings.capabilities).map((key) => {
-                         const capKey = key as keyof typeof settings.capabilities;
-                         const label = key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
+                    {(Object.entries(settings.capabilities) as [CapabilityKey, boolean][]).map(([capKey, enabled]) => {
+                         const label = capKey.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
                          return (
-                            <div key={key} className="flex items-center gap-2">
-                                <input 
-                                    type="checkbox" 
-                                    id={`cap-${key}`} 
-                                    checked={settings.capabilities[capKey]} 
-                                    onChange={e => handleCapabilityChange(capKey, e.target.checked)} 
-                                    className="h-4 w-4 rounded bg-input border-border-color text-primary focus:ring-2 focus:ring-ring" 
+                            <div key={capKey} className="flex items-center gap-2">
+                                <input
+                                    type="checkbox"
+                                    id={`cap-${capKey}`}
+                                    checked={enabled}
+                                    onChange={e => handleCapabilityChange(capKey, e.target.checked)}
+                                    className="h-4 w-4 rounded bg-input border-border-color text-primary focus:ring-2 focus:ring-ring"
                                 />
-                                <Label htmlFor={`cap-${key}`} className="mb-0 text-sm text-text-primary">{label}</Label>
+                                <Label htmlFor={`cap-${capKey}`} className="mb-0 text-sm text-text-primary">{label}</Label>
                             </div>
                          );
                     })}

--- a/components/views/viewers/RequestSplitterViewer.tsx
+++ b/components/views/viewers/RequestSplitterViewer.tsx
@@ -1,6 +1,7 @@
 
 
 import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
+import type { JSX } from 'react';
 import type { RequestSplitterOutput, SplitPlanPrompt } from '../../../types';
 import { enhanceCodeBlocks } from '../../../utils/uiUtils';
 

--- a/components/views/viewers/ScaffolderViewer.tsx
+++ b/components/views/viewers/ScaffolderViewer.tsx
@@ -1,6 +1,7 @@
 
 
 import React, { useEffect, useRef, useState } from 'react';
+import type { JSX } from 'react';
 import type { ScaffolderOutput, ScaffoldTreeItem } from '../../../types';
 import { ChevronRightIcon } from '../../icons/ChevronRightIcon';
 import { enhanceCodeBlocks } from '../../../utils/uiUtils';

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,17 @@
 
 
-import type { ProgressUpdate, ReasoningSettings, ScaffolderSettings, RequestSplitterSettings, PromptEnhancerSettings, AgentDesignerSettings, ChatSettings } from './types';
+import type {
+  ProgressUpdate,
+  ReasoningSettings,
+  ScaffolderSettings,
+  RequestSplitterSettings,
+  PromptEnhancerSettings,
+  AgentDesignerSettings,
+  ChatSettings,
+  AIProviderId,
+  EmbeddingProviderId,
+  AIProviderSettings,
+} from './types';
 
 // Import all summary prompts from the new modular structure
 import * as summaryPrompts from './prompts/summaries';
@@ -26,6 +37,13 @@ export const DEFAULT_PROVIDER_MODELS: Record<AIProviderId, string> = {
   deepseek: 'deepseek-chat',
   anthropic: 'claude-3-5-sonnet-latest',
   ollama: 'llama3.1:8b',
+};
+
+export const INITIAL_AI_PROVIDER_SETTINGS: AIProviderSettings = {
+  selectedProvider: 'openai',
+  selectedModel: DEFAULT_PROVIDER_MODELS.openai,
+  apiKeys: {},
+  featureModelPreferences: undefined,
 };
 
 export const DEFAULT_EMBEDDING_MODELS: Record<EmbeddingProviderId, string> = {
@@ -116,6 +134,19 @@ export const INITIAL_AGENT_DESIGNER_SETTINGS: AgentDesignerSettings = {
 
 export const INITIAL_CHAT_SETTINGS: ChatSettings = {
     systemInstruction: 'You are a helpful and friendly AI assistant. Answer the user\'s questions clearly and concisely.',
+    vectorStore: {
+        enabled: false,
+        url: '',
+        apiKey: undefined,
+        collection: '',
+        topK: 5,
+        embedding: {
+            provider: 'openai',
+            model: DEFAULT_EMBEDDING_MODELS.openai,
+            apiKey: undefined,
+            baseUrl: '',
+        },
+    },
 };
 
 // --- Prompt Collections (Re-constructed from imports) ---

--- a/hooks/usePersistentProviderSettings.ts
+++ b/hooks/usePersistentProviderSettings.ts
@@ -1,9 +1,43 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { AIProviderSettings } from '../types';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { AIProviderSettings, FeatureModelPreferences, Mode } from '../types';
 import { DEFAULT_PROVIDER_MODELS, INITIAL_AI_PROVIDER_SETTINGS } from '../constants';
 import { AI_PROVIDERS, getProviderLabel } from '../services/providerRegistry';
+import { sanitizeFeatureModelPreferences } from '../utils/providerSettings';
 
 const PROVIDER_SETTINGS_STORAGE_KEY = 'ai_content_suite_provider_settings';
+const AVAILABLE_PROVIDER_IDS = new Set(AI_PROVIDERS.map(provider => provider.id));
+
+const hasOverrides = (preferences?: FeatureModelPreferences): boolean =>
+  Boolean(preferences && Object.keys(preferences).length > 0);
+
+const sanitizeSettings = (settings: AIProviderSettings): AIProviderSettings => {
+  const selectedProvider = AVAILABLE_PROVIDER_IDS.has(settings.selectedProvider)
+    ? settings.selectedProvider
+    : INITIAL_AI_PROVIDER_SETTINGS.selectedProvider;
+
+  const fallbackModel =
+    DEFAULT_PROVIDER_MODELS[selectedProvider] ??
+    DEFAULT_PROVIDER_MODELS[INITIAL_AI_PROVIDER_SETTINGS.selectedProvider];
+
+  const selectedModel =
+    typeof settings.selectedModel === 'string' && settings.selectedModel.trim().length > 0
+      ? settings.selectedModel.trim()
+      : fallbackModel;
+
+  const apiKeys =
+    settings.apiKeys && typeof settings.apiKeys === 'object' && settings.apiKeys !== null
+      ? settings.apiKeys
+      : {};
+
+  const sanitizedPreferences = sanitizeFeatureModelPreferences(settings.featureModelPreferences);
+
+  return {
+    selectedProvider,
+    selectedModel,
+    apiKeys,
+    featureModelPreferences: hasOverrides(sanitizedPreferences) ? sanitizedPreferences : undefined,
+  };
+};
 
 const getInitialProviderSettings = (): AIProviderSettings => {
   if (typeof window === 'undefined') {
@@ -21,36 +55,31 @@ const getInitialProviderSettings = (): AIProviderSettings => {
       return INITIAL_AI_PROVIDER_SETTINGS;
     }
 
-    const availableProviders = new Set(AI_PROVIDERS.map(provider => provider.id));
-    const selectedProvider = availableProviders.has(parsed.selectedProvider)
-      ? parsed.selectedProvider!
-      : INITIAL_AI_PROVIDER_SETTINGS.selectedProvider;
-
-    const fallbackModel =
-      DEFAULT_PROVIDER_MODELS[selectedProvider] ??
-      DEFAULT_PROVIDER_MODELS[INITIAL_AI_PROVIDER_SETTINGS.selectedProvider];
-
-    const selectedModel =
-      typeof parsed.selectedModel === 'string' && parsed.selectedModel.trim().length > 0
-        ? parsed.selectedModel
-        : fallbackModel;
-
-    const apiKeys =
-      parsed.apiKeys && typeof parsed.apiKeys === 'object' && parsed.apiKeys !== null ? parsed.apiKeys : {};
-
-    return {
-      selectedProvider,
-      selectedModel,
-      apiKeys,
+    const candidate: AIProviderSettings = {
+      selectedProvider: parsed.selectedProvider ?? INITIAL_AI_PROVIDER_SETTINGS.selectedProvider,
+      selectedModel: parsed.selectedModel ?? INITIAL_AI_PROVIDER_SETTINGS.selectedModel,
+      apiKeys: parsed.apiKeys ?? {},
+      featureModelPreferences: parsed.featureModelPreferences,
     };
+
+    return sanitizeSettings(candidate);
   } catch (error) {
     console.error('Failed to load provider settings from local storage:', error);
     return INITIAL_AI_PROVIDER_SETTINGS;
   }
 };
 
-export const usePersistentProviderSettings = () => {
-  const [providerSettings, setProviderSettings] = useState<AIProviderSettings>(getInitialProviderSettings);
+type ProviderSettingsUpdater = AIProviderSettings | ((prev: AIProviderSettings) => AIProviderSettings);
+
+export const usePersistentProviderSettings = (activeMode?: Mode) => {
+  const [providerSettings, setProviderSettingsState] = useState<AIProviderSettings>(getInitialProviderSettings);
+
+  const setProviderSettings = useCallback((updater: ProviderSettingsUpdater) => {
+    setProviderSettingsState(prev => {
+      const next = typeof updater === 'function' ? (updater as (prev: AIProviderSettings) => AIProviderSettings)(prev) : updater;
+      return sanitizeSettings(next);
+    });
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -58,34 +87,54 @@ export const usePersistentProviderSettings = () => {
     }
 
     try {
-      localStorage.setItem(PROVIDER_SETTINGS_STORAGE_KEY, JSON.stringify(providerSettings));
+      const sanitized = sanitizeSettings(providerSettings);
+      localStorage.setItem(PROVIDER_SETTINGS_STORAGE_KEY, JSON.stringify(sanitized));
     } catch (error) {
       console.error('Failed to save provider settings to local storage:', error);
     }
   }, [providerSettings]);
 
+  const resolveProviderForMode = useCallback(
+    (mode?: Mode) => {
+      const override = mode ? providerSettings.featureModelPreferences?.[mode] : undefined;
+      const providerId =
+        override && AVAILABLE_PROVIDER_IDS.has(override.provider)
+          ? override.provider
+          : providerSettings.selectedProvider;
+
+      const fallbackModel =
+        DEFAULT_PROVIDER_MODELS[providerId] ??
+        DEFAULT_PROVIDER_MODELS[providerSettings.selectedProvider];
+
+      const candidateModel = override?.model ?? providerSettings.selectedModel;
+      const trimmedModel = typeof candidateModel === 'string' ? candidateModel.trim() : '';
+
+      return {
+        providerId,
+        model: trimmedModel.length > 0 ? trimmedModel : fallbackModel,
+      };
+    },
+    [providerSettings],
+  );
+
+  const resolvedSelection = useMemo(() => resolveProviderForMode(activeMode), [activeMode, resolveProviderForMode]);
+
   const activeProviderInfo = useMemo(
-    () => AI_PROVIDERS.find(provider => provider.id === providerSettings.selectedProvider),
-    [providerSettings.selectedProvider],
+    () => AI_PROVIDERS.find(provider => provider.id === resolvedSelection.providerId),
+    [resolvedSelection.providerId],
   );
 
   const activeProviderLabel = useMemo(
-    () => getProviderLabel(providerSettings.selectedProvider),
-    [providerSettings.selectedProvider],
+    () => getProviderLabel(resolvedSelection.providerId),
+    [resolvedSelection.providerId],
   );
 
-  const activeModelName = useMemo(() => {
-    const trimmed = providerSettings.selectedModel?.trim();
-    if (trimmed && trimmed.length > 0) {
-      return trimmed;
-    }
-    return DEFAULT_PROVIDER_MODELS[providerSettings.selectedProvider] ?? '';
-  }, [providerSettings]);
+  const activeModelName = resolvedSelection.model;
 
   const isApiKeyConfigured = useMemo(() => {
-    const key = providerSettings.apiKeys?.[providerSettings.selectedProvider];
+    const key = providerSettings.apiKeys?.[resolvedSelection.providerId];
     return typeof key === 'string' && key.trim().length > 0;
-  }, [providerSettings]);
+  }, [providerSettings.apiKeys, resolvedSelection.providerId]);
 
   const providerStatusText = useMemo(() => {
     if (!activeProviderInfo) return 'Provider status unavailable';
@@ -111,6 +160,7 @@ export const usePersistentProviderSettings = () => {
   return {
     providerSettings,
     setProviderSettings,
+    resolveProviderForMode,
     activeProviderInfo,
     activeProviderLabel,
     activeModelName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,58 @@
         "tesseract.js": "5.1.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.2.0",
         "@types/node": "^22.14.0",
         "@vitejs/plugin-react": "^5.0.0",
+        "@vitest/coverage-v8": "^2.1.6",
+        "jsdom": "^25.0.1",
         "typescript": "~5.8.2",
-        "vite": "^6.2.0"
+        "vite": "^6.2.0",
+        "vitest": "^2.1.6"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -255,6 +302,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -301,6 +358,128 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -745,6 +924,88 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -854,6 +1115,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1171,11 +1443,95 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.8.0.tgz",
+      "integrity": "sha512-WgXcWzVM6idy5JaftTVC8Vs83NKRmGJz4Hqs4oyOuO2J4r/y79vvKZsb+CaGyCSEbUPI6OsewfPd0G1A0/TUZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
       "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
       "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1260,6 +1616,125 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -1276,14 +1751,38 @@
         "node": ">=12"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/aproba": {
@@ -1308,12 +1807,39 @@
         "node": ">=10"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
@@ -1386,6 +1912,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001743",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
@@ -1435,6 +1985,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -1445,6 +2022,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
@@ -1453,6 +2050,19 @@
       "optional": true,
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/concat-map": {
@@ -1473,6 +2083,49 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1692,6 +2345,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1710,6 +2414,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -1723,12 +2434,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.0",
@@ -1739,6 +2480,36 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.222",
@@ -1751,8 +2522,77 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -1804,6 +2644,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1864,6 +2724,53 @@
         "node": ">=12"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -1919,6 +2826,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
@@ -1951,6 +2868,45 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1973,6 +2929,58 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -1980,11 +2988,95 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/idb-keyval": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
       "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/index-array-by": {
       "version": "1.4.2",
@@ -2033,17 +3125,130 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jerrypick": {
       "version": "1.1.2",
@@ -2059,6 +3264,84 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2116,6 +3399,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2124,6 +3414,39 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -2142,6 +3465,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
@@ -2153,6 +3509,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2172,8 +3538,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2315,6 +3681,13 @@
         "set-blocking": "^2.0.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.22.tgz",
+      "integrity": "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2343,6 +3716,26 @@
         "opencollective-postinstall": "index.js"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2353,6 +3746,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/path2d": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
@@ -2361,6 +3788,23 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pdfjs-dist": {
@@ -2435,6 +3879,30 @@
         "url": "https://opencollective.com/preact"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -2444,6 +3912,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/react": {
@@ -2530,6 +4008,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -2595,6 +4087,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2615,6 +4114,26 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -2638,6 +4157,36 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -2689,6 +4238,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -2703,8 +4266,24 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2718,14 +4297,61 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "6.2.1",
@@ -2777,10 +4403,96 @@
       "integrity": "sha512-KX3bYSU5iGcO1XJa+QGPbi+Zjo2qq6eBhNjSGR5E5q0JtzkoipJKOUQD7ph8kFyteCEfEQ0maWLu8MCXtvX5uQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -2798,6 +4510,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -2940,6 +4715,1115 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wasm-feature-detect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
@@ -2952,6 +5836,29 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -2960,6 +5867,39 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -2972,12 +5912,171 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,19 +6,26 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "pdfjs-dist": "4.4.168",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "pdfjs-dist": "4.4.168",
+    "react-force-graph-2d": "^1.29.0",
     "tesseract.js": "5.1.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "jsdom": "^25.0.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^2.1.6",
+    "@vitest/coverage-v8": "^2.1.6"
   }
 }

--- a/react-force-graph-2d.d.ts
+++ b/react-force-graph-2d.d.ts
@@ -1,0 +1,21 @@
+declare module 'react-force-graph-2d' {
+  import type { ComponentType } from 'react';
+
+  export type NodeObject<NodeType = any> = NodeType & { [key: string]: any };
+  export type LinkObject<NodeType = any, LinkType = any> = LinkType & {
+    source: NodeObject<NodeType> | string | number;
+    target: NodeObject<NodeType> | string | number;
+  };
+  export interface GraphData<NodeType = any, LinkType = any> {
+    nodes: NodeObject<NodeType>[];
+    links: LinkObject<NodeType, LinkType>[];
+  }
+  export interface ForceGraphMethods<NodeType = any, LinkType = any> {
+    d3Force: (...args: any[]) => any;
+    zoomToFit: (ms?: number, padding?: number) => void;
+    centerAt: (x: number, y: number, ms?: number) => void;
+  }
+
+  const ForceGraph2D: ComponentType<any>;
+  export default ForceGraph2D;
+}

--- a/services/providerRegistry.ts
+++ b/services/providerRegistry.ts
@@ -1,0 +1,169 @@
+import type { AIProviderId, ModelOption, EmbeddingProviderId } from '../types';
+import { DEFAULT_PROVIDER_MODELS } from '../constants';
+
+export interface ProviderInfo {
+  id: AIProviderId;
+  label: string;
+  requiresApiKey: boolean;
+  docsUrl?: string;
+}
+
+export interface EmbeddingProviderInfo {
+  id: EmbeddingProviderId;
+  label: string;
+  requiresApiKey: boolean;
+  docsUrl?: string;
+  defaultEndpoint?: string;
+}
+
+export const ANTHROPIC_API_VERSION = '2023-06-01';
+
+export const AI_PROVIDERS: ProviderInfo[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.openai.com/docs/api-reference',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    requiresApiKey: true,
+    docsUrl: 'https://openrouter.ai/docs',
+  },
+  {
+    id: 'xai',
+    label: 'xAI (Grok)',
+    requiresApiKey: true,
+    docsUrl: 'https://docs.x.ai/',
+  },
+  {
+    id: 'deepseek',
+    label: 'DeepSeek',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.deepseek.com/docs',
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic Claude',
+    requiresApiKey: true,
+    docsUrl: 'https://docs.anthropic.com/claude',
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (Local)',
+    requiresApiKey: false,
+    docsUrl: 'https://github.com/ollama/ollama',
+  },
+];
+
+export const EMBEDDING_PROVIDERS: EmbeddingProviderInfo[] = [
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.openai.com/docs/guides/embeddings',
+    defaultEndpoint: 'https://api.openai.com/v1/embeddings',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    requiresApiKey: true,
+    docsUrl: 'https://openrouter.ai/docs',
+    defaultEndpoint: 'https://openrouter.ai/api/v1/embeddings',
+  },
+  {
+    id: 'deepseek',
+    label: 'DeepSeek',
+    requiresApiKey: true,
+    docsUrl: 'https://platform.deepseek.com/docs',
+    defaultEndpoint: 'https://api.deepseek.com/v1/embeddings',
+  },
+  {
+    id: 'ollama',
+    label: 'Ollama (Local)',
+    requiresApiKey: false,
+    docsUrl: 'https://github.com/ollama/ollama',
+    defaultEndpoint: 'http://localhost:11434/api/embeddings',
+  },
+  {
+    id: 'custom',
+    label: 'Custom Endpoint',
+    requiresApiKey: false,
+  },
+];
+
+const DEFAULT_MODEL_OPTIONS: Record<AIProviderId, ModelOption[]> = {
+  openai: [
+    { id: 'gpt-4o', label: 'gpt-4o', description: 'Flagship general-purpose model' },
+    { id: 'gpt-4o-mini', label: 'gpt-4o-mini', description: 'Fast and cost-effective 4o variant' },
+    { id: 'o1-mini', label: 'o1-mini', description: 'Reasoning-optimised model' },
+  ],
+  openrouter: [
+    { id: 'openrouter/auto', label: 'openrouter/auto', description: 'Smart router that picks the best model' },
+    { id: 'anthropic/claude-3.5-sonnet', label: 'anthropic/claude-3.5-sonnet', description: 'Anthropic Claude via OpenRouter' },
+    { id: 'google/gemini-pro', label: 'google/gemini-pro', description: 'Gemini Pro via OpenRouter' },
+  ],
+  xai: [
+    { id: 'grok-beta', label: 'grok-beta', description: 'General purpose Grok model' },
+    { id: 'grok-vision-beta', label: 'grok-vision-beta', description: 'Multimodal Grok variant with vision' },
+  ],
+  deepseek: [
+    { id: 'deepseek-chat', label: 'deepseek-chat', description: 'DeepSeek general chat model' },
+    { id: 'deepseek-coder', label: 'deepseek-coder', description: 'DeepSeek code-focused model' },
+  ],
+  anthropic: [
+    { id: 'claude-3-5-sonnet-latest', label: 'claude-3.5-sonnet-latest', description: 'Latest Claude 3.5 Sonnet release' },
+    { id: 'claude-3-opus-latest', label: 'claude-3-opus-latest', description: 'Claude 3 Opus for high quality outputs' },
+  ],
+  ollama: [
+    { id: 'llama3.1:8b', label: 'llama3.1:8b', description: 'Meta Llama 3.1 8B local model' },
+    { id: 'llama3.1:70b', label: 'llama3.1:70b', description: 'Meta Llama 3.1 70B local model' },
+    { id: 'qwen2.5:14b', label: 'qwen2.5:14b', description: 'Qwen 2.5 local model' },
+  ],
+};
+
+const providerModelOptions: Record<AIProviderId, ModelOption[]> = Object.fromEntries(
+  (Object.entries(DEFAULT_MODEL_OPTIONS) as Array<[AIProviderId, ModelOption[]]>).map(([providerId, models]) => [
+    providerId,
+    [...models],
+  ]),
+) as Record<AIProviderId, ModelOption[]>;
+
+export const registerProviderModels = (providerId: AIProviderId, models: ModelOption[]): void => {
+  providerModelOptions[providerId] = models.map(model => ({ ...model }));
+};
+
+export const getProviderLabel = (providerId: AIProviderId): string => {
+  return AI_PROVIDERS.find(provider => provider.id === providerId)?.label ?? providerId;
+};
+
+export const requiresApiKey = (providerId: AIProviderId): boolean => {
+  return AI_PROVIDERS.find(provider => provider.id === providerId)?.requiresApiKey ?? true;
+};
+
+export const requiresEmbeddingApiKey = (providerId: EmbeddingProviderId): boolean => {
+  return EMBEDDING_PROVIDERS.find(provider => provider.id === providerId)?.requiresApiKey ?? false;
+};
+
+export const getEmbeddingProviderDefaultEndpoint = (
+  providerId: EmbeddingProviderId,
+): string | undefined => {
+  return EMBEDDING_PROVIDERS.find(provider => provider.id === providerId)?.defaultEndpoint;
+};
+
+export const fetchModelsForProvider = async (
+  providerId: AIProviderId,
+  apiKey?: string,
+): Promise<ModelOption[]> => {
+  void apiKey; // Currently unused but retained for future dynamic fetching support
+  const models = providerModelOptions[providerId];
+  if (models && models.length > 0) {
+    return models.map(model => ({ ...model }));
+  }
+  const fallback = DEFAULT_PROVIDER_MODELS[providerId];
+  if (fallback) {
+    return [{ id: fallback, label: fallback }];
+  }
+  return [];
+};

--- a/services/submissionService.ts
+++ b/services/submissionService.ts
@@ -1,3 +1,4 @@
+import type { Dispatch, SetStateAction } from 'react';
 import { processTranscript } from './summarizationService';
 import { processStyleExtraction } from './styleExtractionService';
 import { processRewrite } from './rewriterService';
@@ -29,12 +30,12 @@ interface SubmissionArgs {
     activeMode: Mode;
     currentFiles: File[] | null;
     settings: AllSettings;
-    setAppState: React.Dispatch<React.SetStateAction<AppState>>;
-    setError: React.Dispatch<React.SetStateAction<ProcessingError | null>>;
-    setProcessedData: React.Dispatch<React.SetStateAction<ProcessedOutput | null>>;
-    setProgress: React.Dispatch<React.SetStateAction<ProgressUpdate>>;
-    setNextStepSuggestions: React.Dispatch<React.SetStateAction<string[] | null>>;
-    setSuggestionsLoading: React.Dispatch<React.SetStateAction<boolean>>;
+    setAppState: Dispatch<SetStateAction<AppState>>;
+    setError: Dispatch<SetStateAction<ProcessingError | null>>;
+    setProcessedData: Dispatch<SetStateAction<ProcessedOutput | null>>;
+    setProgress: Dispatch<SetStateAction<ProgressUpdate>>;
+    setNextStepSuggestions: Dispatch<SetStateAction<string[] | null>>;
+    setSuggestionsLoading: Dispatch<SetStateAction<boolean>>;
     signal: AbortSignal;
 }
 

--- a/tests/deepClone.test.ts
+++ b/tests/deepClone.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { deepClone } from '../utils/deepClone';
+
+const globalWithClone = globalThis as typeof globalThis & { structuredClone?: typeof globalThis.structuredClone };
+const originalStructuredClone = globalWithClone.structuredClone;
+
+afterEach(() => {
+  globalWithClone.structuredClone = originalStructuredClone;
+});
+
+describe('deepClone', () => {
+  it('uses the native structuredClone when available', () => {
+    if (typeof originalStructuredClone !== 'function') {
+      // Environment without structuredClone will still exercise the fallback in other tests
+      globalWithClone.structuredClone = (value: unknown) => JSON.parse(JSON.stringify(value));
+    }
+
+    const source = { greeting: 'hello', nested: { value: 42 } };
+    const result = deepClone(source);
+
+    expect(result).toEqual(source);
+    expect(result).not.toBe(source);
+    expect(result.nested).not.toBe(source.nested);
+  });
+
+  it('falls back to JSON cloning when structuredClone is unavailable', () => {
+    globalWithClone.structuredClone = undefined;
+
+    const source = { items: [1, 2, 3], note: 'fallback path' };
+    const result = deepClone(source);
+
+    expect(result).toEqual(source);
+    expect(result).not.toBe(source);
+  });
+});

--- a/tests/providerRegistry.test.ts
+++ b/tests/providerRegistry.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  AI_PROVIDERS,
+  EMBEDDING_PROVIDERS,
+  fetchModelsForProvider,
+  getProviderLabel,
+  requiresApiKey,
+  requiresEmbeddingApiKey,
+  getEmbeddingProviderDefaultEndpoint,
+  registerProviderModels,
+} from '../services/providerRegistry';
+import { DEFAULT_PROVIDER_MODELS } from '../constants';
+import type { AIProviderId, EmbeddingProviderId, ModelOption } from '../types';
+
+const captureDefaultModels = async (): Promise<Record<AIProviderId, ModelOption[]>> => {
+  const defaults: Partial<Record<AIProviderId, ModelOption[]>> = {};
+  await Promise.all(
+    AI_PROVIDERS.map(async provider => {
+      defaults[provider.id] = await fetchModelsForProvider(provider.id);
+    }),
+  );
+  return defaults as Record<AIProviderId, ModelOption[]>;
+};
+
+let originalModels: Record<AIProviderId, ModelOption[]>;
+
+beforeEach(async () => {
+  originalModels = await captureDefaultModels();
+});
+
+afterEach(() => {
+  for (const provider of AI_PROVIDERS) {
+    registerProviderModels(provider.id, originalModels[provider.id]);
+  }
+});
+
+describe('providerRegistry', () => {
+  it('exposes the expected provider metadata', () => {
+    expect(AI_PROVIDERS.map(provider => provider.id)).toEqual([
+      'openai',
+      'openrouter',
+      'xai',
+      'deepseek',
+      'anthropic',
+      'ollama',
+    ]);
+    expect(AI_PROVIDERS.every(provider => provider.label.length > 0)).toBe(true);
+  });
+
+  it('returns a friendly provider label or falls back to the id', () => {
+    expect(getProviderLabel('openai')).toBe('OpenAI');
+    const unknownProvider = 'made-up-provider' as AIProviderId;
+    expect(getProviderLabel(unknownProvider)).toBe(unknownProvider);
+  });
+
+  it('reports whether an API key is required for generation providers', () => {
+    expect(requiresApiKey('openai')).toBe(true);
+    expect(requiresApiKey('ollama')).toBe(false);
+    const unknownProvider = 'non-existent-provider' as AIProviderId;
+    expect(requiresApiKey(unknownProvider)).toBe(true);
+  });
+
+  it('reports API key requirements for embedding providers', () => {
+    const providerWithKey = EMBEDDING_PROVIDERS.find(provider => provider.id === 'openai');
+    expect(providerWithKey?.requiresApiKey).toBe(true);
+    expect(requiresEmbeddingApiKey('openrouter')).toBe(true);
+    expect(requiresEmbeddingApiKey('custom')).toBe(false);
+    const unknownEmbedding = 'missing' as EmbeddingProviderId;
+    expect(requiresEmbeddingApiKey(unknownEmbedding)).toBe(false);
+  });
+
+  it('returns default embedding endpoints when available', () => {
+    expect(getEmbeddingProviderDefaultEndpoint('openai')).toMatch('api.openai.com');
+    expect(getEmbeddingProviderDefaultEndpoint('custom')).toBeUndefined();
+  });
+
+  it('returns the registered models for a provider', async () => {
+    const customModels: ModelOption[] = [
+      { id: 'custom-model', label: 'Custom Model' },
+    ];
+    registerProviderModels('openai', customModels);
+
+    const models = await fetchModelsForProvider('openai');
+    expect(models).toEqual(customModels);
+    expect(models).not.toBe(customModels); // defensive copy
+  });
+
+  it('falls back to default models when none are registered for a known provider', async () => {
+    registerProviderModels('openai', []);
+
+    const models = await fetchModelsForProvider('openai');
+    expect(models).toEqual([
+      {
+        id: DEFAULT_PROVIDER_MODELS.openai,
+        label: DEFAULT_PROVIDER_MODELS.openai,
+      },
+    ]);
+  });
+
+  it('returns an empty list for completely unknown providers', async () => {
+    const unknownProvider = 'totally-unknown' as AIProviderId;
+    const models = await fetchModelsForProvider(unknownProvider);
+    expect(models).toEqual([]);
+  });
+});

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/tests/useChatSubmission.test.ts
+++ b/tests/useChatSubmission.test.ts
@@ -1,0 +1,363 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FormEvent } from 'react';
+import { useChatSubmission } from '../hooks/useChatSubmission';
+import type { WorkspaceState } from '../hooks/useWorkspaceState';
+import type { SetModeValue } from '../hooks/useMainFormProps';
+import {
+  INITIAL_AGENT_DESIGNER_SETTINGS,
+  INITIAL_PROMPT_ENHANCER_SETTINGS,
+  INITIAL_PROGRESS,
+  INITIAL_REASONING_SETTINGS,
+  INITIAL_REQUEST_SPLITTER_SETTINGS,
+  INITIAL_SCAFFOLDER_SETTINGS,
+} from '../constants';
+import { deepClone } from '../utils/deepClone';
+import type { AIProviderSettings, ChatSettings, Mode } from '../types';
+import type { ProviderInfo } from '../services/providerRegistry';
+import { sendChatMessage } from '../services/geminiService';
+import { fileToGenerativePart } from '../utils/fileUtils';
+
+vi.mock('../services/geminiService', () => ({
+  sendChatMessage: vi.fn(),
+}));
+
+vi.mock('../utils/fileUtils', () => ({
+  fileToGenerativePart: vi.fn(),
+}));
+
+const sendChatMessageMock = vi.mocked(sendChatMessage);
+const fileToGenerativePartMock = vi.mocked(fileToGenerativePart);
+
+type HookParams = Parameters<typeof useChatSubmission>[0];
+
+const createWorkspaceState = (): WorkspaceState => ({
+  currentFiles: null,
+  appState: 'idle',
+  progress: deepClone(INITIAL_PROGRESS),
+  processedData: null,
+  error: null,
+  nextStepSuggestions: null,
+  suggestionsLoading: false,
+  styleTarget: '',
+  rewriteStyle: '',
+  rewriteInstructions: '',
+  rewriteLength: 'medium',
+  useHierarchical: false,
+  summaryFormat: 'default',
+  summarySearchTerm: '',
+  summaryTextInput: '',
+  reasoningPrompt: '',
+  reasoningSettings: deepClone(INITIAL_REASONING_SETTINGS),
+  scaffolderPrompt: '',
+  scaffolderSettings: deepClone(INITIAL_SCAFFOLDER_SETTINGS),
+  requestSplitterSpec: '',
+  requestSplitterSettings: deepClone(INITIAL_REQUEST_SPLITTER_SETTINGS),
+  promptEnhancerSettings: deepClone(INITIAL_PROMPT_ENHANCER_SETTINGS),
+  agentDesignerSettings: deepClone(INITIAL_AGENT_DESIGNER_SETTINGS),
+  chatHistory: [],
+  isStreamingResponse: false,
+  chatInput: '',
+  chatFiles: null,
+});
+
+const createSetModeValue = (state: WorkspaceState) => {
+  const impl: SetModeValue = (key, value) => {
+    const current = state[key];
+    const nextValue = typeof value === 'function' ? (value as (prev: typeof current) => typeof current)(current) : value;
+    (state as unknown as Record<string, unknown>)[key as string] = nextValue as unknown;
+  };
+  return vi.fn(impl);
+};
+
+const createParams = (
+  state: WorkspaceState,
+  overrides: Partial<HookParams> = {},
+): HookParams & { setModeValue: ReturnType<typeof createSetModeValue>; getStateForMode: ReturnType<typeof vi.fn> } => {
+  const aiProviderSettings: AIProviderSettings = overrides.aiProviderSettings ?? {
+    selectedProvider: 'openai',
+    selectedModel: 'gpt-4o-mini',
+    apiKeys: { openai: 'sk-test-key' },
+  };
+  const chatSettings: ChatSettings = overrides.chatSettings ?? { systemInstruction: 'Be helpful' };
+  const activeProviderInfo: ProviderInfo | undefined = overrides.activeProviderInfo ?? {
+    id: 'openai',
+    label: 'OpenAI',
+    requiresApiKey: true,
+  };
+  const setModeValue = createSetModeValue(state);
+  const getStateForMode = vi.fn(() => state);
+  const resolveProviderForMode = overrides.resolveProviderForMode ?? (() => ({
+    providerId: aiProviderSettings.selectedProvider,
+    model: aiProviderSettings.selectedModel,
+  }));
+
+  return {
+    activeMode: (overrides.activeMode ?? 'chat') as Mode,
+    aiProviderSettings,
+    activeProviderInfo,
+    resolveProviderForMode,
+    chatSettings,
+    canSubmit: overrides.canSubmit ?? true,
+    chatInput: overrides.chatInput ?? state.chatInput ?? '',
+    chatFiles: overrides.chatFiles ?? state.chatFiles ?? null,
+    getStateForMode,
+    setModeValue,
+  };
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('useChatSubmission', () => {
+  it('prevents submission when canSubmit is false', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { canSubmit: false, chatInput: 'Hello' });
+    const { result } = renderHook(() => useChatSubmission(params));
+    const preventDefault = vi.fn();
+
+    await act(async () => {
+      await result.current({ preventDefault } as unknown as FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(sendChatMessageMock).not.toHaveBeenCalled();
+    expect(params.setModeValue).not.toHaveBeenCalled();
+    expect(state.chatHistory).toEqual([]);
+  });
+
+  it('requires an API key when the provider needs one', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, {
+      aiProviderSettings: {
+        selectedProvider: 'openai',
+        selectedModel: 'gpt-4o-mini',
+        apiKeys: {},
+      },
+      chatInput: 'Hello world',
+    });
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(sendChatMessageMock).not.toHaveBeenCalled();
+    expect(state.error).toEqual({
+      message: 'OpenAI requires an API key. Please add it in settings before starting a chat.',
+    });
+    expect(state.chatHistory).toEqual([]);
+  });
+
+  it('checks API key requirements against per-feature overrides', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, {
+      aiProviderSettings: {
+        selectedProvider: 'openai',
+        selectedModel: 'gpt-4o-mini',
+        apiKeys: { openai: 'sk-test-key' },
+      },
+      activeProviderInfo: {
+        id: 'openrouter',
+        label: 'OpenRouter',
+        requiresApiKey: true,
+      },
+      resolveProviderForMode: () => ({ providerId: 'openrouter', model: 'openrouter/auto' }),
+      chatInput: 'Hello override',
+    });
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(sendChatMessageMock).not.toHaveBeenCalled();
+    expect(state.error).toEqual({
+      message: 'OpenRouter requires an API key. Please add it in settings before starting a chat.',
+    });
+    expect(state.chatHistory).toEqual([]);
+  });
+
+  it('returns early when no text or files are provided', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: '   ', chatFiles: [] });
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(sendChatMessageMock).not.toHaveBeenCalled();
+    expect(params.setModeValue).not.toHaveBeenCalled();
+  });
+
+  it('sends a chat message and updates chat history', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: 'Hello model' });
+    sendChatMessageMock.mockResolvedValue({
+      text: 'Response text',
+      thinking: [
+        { label: 'Reasoning', text: 'Deliberation trace' },
+      ],
+    });
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(sendChatMessageMock).toHaveBeenCalledWith({
+      history: [],
+      userMessage: [{ text: 'Hello model' }],
+      systemInstruction: 'Be helpful',
+      vectorStoreSettings: undefined,
+    });
+    expect(state.chatHistory).toHaveLength(2);
+    expect(state.chatHistory[0]).toEqual({ role: 'user', parts: [{ text: 'Hello model' }] });
+    expect(state.chatHistory[1]).toEqual({
+      role: 'model',
+      parts: [{ text: 'Response text' }],
+      thinking: [
+        { label: 'Reasoning', text: 'Deliberation trace' },
+      ],
+    });
+    expect(state.chatInput).toBe('');
+    expect(state.chatFiles).toBeNull();
+    expect(state.isStreamingResponse).toBe(false);
+    expect(state.error).toBeNull();
+    expect(fileToGenerativePartMock).not.toHaveBeenCalled();
+  });
+
+  it('converts attached files to generative parts before sending', async () => {
+    const state = createWorkspaceState();
+    const file = new File(['binary'], 'diagram.png', { type: 'image/png' });
+    fileToGenerativePartMock.mockResolvedValue({ inlineData: { mimeType: 'image/png', data: 'base64-data' } });
+    sendChatMessageMock.mockResolvedValue({ text: 'ok', thinking: [] });
+
+    const params = createParams(state, {
+      chatInput: '   ',
+      chatFiles: [file],
+      activeProviderInfo: { id: 'ollama', label: 'Ollama', requiresApiKey: false },
+      aiProviderSettings: {
+        selectedProvider: 'ollama',
+        selectedModel: 'llama3.1:8b',
+        apiKeys: {},
+      },
+    });
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(fileToGenerativePartMock).toHaveBeenCalledTimes(1);
+    expect(fileToGenerativePartMock.mock.calls[0][0]).toBe(file);
+    expect(sendChatMessageMock).toHaveBeenCalledWith({
+      history: [],
+      userMessage: [{ inlineData: { mimeType: 'image/png', data: 'base64-data' } }],
+      systemInstruction: 'Be helpful',
+      vectorStoreSettings: undefined,
+    });
+    expect(state.chatFiles).toBeNull();
+  });
+
+  it('replaces placeholders that no longer contain text parts', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: 'Needs cleanup' });
+    sendChatMessageMock.mockImplementation(async () => {
+      const placeholder = state.chatHistory[state.chatHistory.length - 1];
+      if (placeholder) {
+        placeholder.parts = [{ inlineData: { mimeType: 'application/octet-stream', data: 'AA==' } }];
+      }
+      return { text: 'Final response', thinking: [] };
+    });
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const lastMessage = state.chatHistory[state.chatHistory.length - 1];
+    expect(lastMessage.role).toBe('model');
+    expect(lastMessage.parts).toEqual([{ text: 'Final response' }]);
+    expect(lastMessage.thinking).toBeUndefined();
+  });
+
+  it('skips response updates when chat history was cleared mid-flight', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: 'History cleared' });
+    sendChatMessageMock.mockImplementation(async () => {
+      state.chatHistory = [];
+      return { text: 'Irrelevant', thinking: [] };
+    });
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(state.chatHistory).toEqual([]);
+  });
+
+  it('handles unknown errors without removing additional history entries', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: 'Trigger unknown failure' });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    sendChatMessageMock.mockImplementation(async () => {
+      state.chatHistory = [];
+      throw 'unexpected failure';
+    });
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(state.error).toEqual({ message: 'Chat failed: An unknown error occurred.' });
+    expect(state.chatHistory).toEqual([]);
+    expect(state.isStreamingResponse).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it('removes the placeholder response when the request is aborted', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: 'Abort please' });
+    sendChatMessageMock.mockRejectedValue(new DOMException('Stopped', 'AbortError'));
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(state.chatHistory).toHaveLength(1);
+    expect(state.chatHistory[0]).toEqual({ role: 'user', parts: [{ text: 'Abort please' }] });
+    expect(state.isStreamingResponse).toBe(false);
+  });
+
+  it('reports errors from the provider and removes the placeholder', async () => {
+    const state = createWorkspaceState();
+    const params = createParams(state, { chatInput: 'Trigger failure' });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    sendChatMessageMock.mockRejectedValue(new Error('Network issue'));
+
+    const { result } = renderHook(() => useChatSubmission(params));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(state.chatHistory).toHaveLength(1);
+    expect(state.chatHistory[0]).toEqual({ role: 'user', parts: [{ text: 'Trigger failure' }] });
+    expect(state.error).toEqual({ message: 'Chat failed: Network issue' });
+    expect(state.isStreamingResponse).toBe(false);
+    consoleError.mockRestore();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,9 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vitest/globals",
+      "@testing-library/jest-dom"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/types.ts
+++ b/types.ts
@@ -4,6 +4,18 @@ export interface Highlight {
   relevance?: number; // Optional, depends on LLM output
 }
 
+export type Mode =
+  | 'technical'
+  | 'styleExtractor'
+  | 'rewriter'
+  | 'mathFormatter'
+  | 'reasoningStudio'
+  | 'scaffolder'
+  | 'requestSplitter'
+  | 'promptEnhancer'
+  | 'agentDesigner'
+  | 'chat';
+
 export type SummaryFormat = 'default' | 'sessionHandoff' | 'readme' | 'solutionFinder' | 'timeline' | 'decisionMatrix' | 'pitchGenerator' | 'causeEffectChain' | 'swotAnalysis' | 'checklist' | 'dialogCondensation' | 'graphTreeOutline' | 'entityRelationshipDigest' | 'rulesDistiller' | 'metricsDashboard' | 'qaPairs' | 'processFlow' | 'raciSnapshot' | 'riskRegister' | 'milestoneTracker' | 'glossaryTermMap' | 'hierarchyOfNeeds' | 'stakeholderMap' | 'constraintList' | 'prosConsTable' | 'priorityRanking' | 'agentSystemInstructions' | 'reverseEngineering' | 'systemWalkthrough';
 
 export interface SummaryOutput {
@@ -308,6 +320,53 @@ export interface AgentDesignerOutput {
 }
 // --- End Agent Designer types ---
 
+// --- New types for Provider & Embedding settings ---
+export type AIProviderId = 'openai' | 'openrouter' | 'xai' | 'deepseek' | 'anthropic' | 'ollama';
+
+export interface FeatureModelPreference {
+  provider: AIProviderId;
+  model: string;
+}
+
+export type FeatureModelPreferences = Partial<Record<Mode, FeatureModelPreference>>;
+
+export interface AIProviderSettings {
+  selectedProvider: AIProviderId;
+  selectedModel: string;
+  apiKeys?: Partial<Record<AIProviderId, string>>;
+  featureModelPreferences?: FeatureModelPreferences;
+}
+
+export interface ModelOption {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export type EmbeddingProviderId = 'openai' | 'openrouter' | 'deepseek' | 'ollama' | 'custom';
+
+export interface EmbeddingSettings {
+  provider: EmbeddingProviderId;
+  model: string;
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface VectorStoreSettings {
+  enabled: boolean;
+  url?: string;
+  apiKey?: string;
+  collection?: string;
+  topK?: number;
+  embedding: EmbeddingSettings;
+}
+
+export interface VectorStoreMatch {
+  text: string;
+  score?: number;
+  metadata?: Record<string, unknown>;
+}
+
 // --- New types for LLM Chat ---
 export interface SavedPrompt {
   name: string;
@@ -352,7 +411,6 @@ export interface ProgressUpdate {
 }
 
 export type AppState = 'idle' | 'fileSelected' | 'processing' | 'completed' | 'error' | 'cancelled';
-export type Mode = 'technical' | 'styleExtractor' | 'rewriter' | 'mathFormatter' | 'reasoningStudio' | 'scaffolder' | 'requestSplitter' | 'promptEnhancer' | 'agentDesigner' | 'chat';
 export type RewriteLength = 'short' | 'medium' | 'long';
 
 

--- a/utils/providerSettings.ts
+++ b/utils/providerSettings.ts
@@ -1,0 +1,37 @@
+import type { FeatureModelPreferences, Mode, AIProviderId } from '../types';
+import { MODE_IDS } from '../constants/uiConstants';
+import { AI_PROVIDERS } from '../services/providerRegistry';
+
+const MODE_SET = new Set<Mode>(MODE_IDS);
+const PROVIDER_SET = new Set<AIProviderId>(AI_PROVIDERS.map(provider => provider.id));
+
+export const sanitizeFeatureModelPreferences = (
+  rawPreferences?: Partial<Record<string, unknown>>,
+): FeatureModelPreferences => {
+  if (!rawPreferences || typeof rawPreferences !== 'object') {
+    return {};
+  }
+
+  const sanitized: FeatureModelPreferences = {};
+  for (const [modeKey, value] of Object.entries(rawPreferences)) {
+    if (!MODE_SET.has(modeKey as Mode)) {
+      continue;
+    }
+    if (!value || typeof value !== 'object') {
+      continue;
+    }
+
+    const providerId = (value as { provider?: AIProviderId }).provider;
+    if (!providerId || !PROVIDER_SET.has(providerId)) {
+      continue;
+    }
+
+    const modelValue = (value as { model?: unknown }).model;
+    sanitized[modeKey as Mode] = {
+      provider: providerId,
+      model: typeof modelValue === 'string' ? modelValue.trim() : '',
+    };
+  }
+
+  return sanitized;
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,24 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
-      }
+      },
+      test: {
+        environment: 'jsdom',
+        setupFiles: ['./tests/setupTests.ts'],
+        coverage: {
+          reporter: ['text', 'lcov'],
+          include: [
+            'hooks/useChatSubmission.ts',
+            'services/providerRegistry.ts',
+            'utils/deepClone.ts',
+          ],
+          thresholds: {
+            lines: 95,
+            functions: 95,
+            branches: 95,
+            statements: 95,
+          },
+        },
+      },
     };
 });


### PR DESCRIPTION
## Summary
- replace the chat-only settings modal with a workspace settings dialog that consolidates provider defaults, per-feature overrides, retrieval configuration, and chat presets
- add a top-level menu bar with a Settings dropdown so the unified modal is accessible outside of the main card
- persist and resolve provider selections per mode, sanitising overrides and enforcing API key requirements during chat submission, and expose a helper for other hooks/components

## Testing
- npm run typecheck
- npm run test
- npm run dev -- --clearScreen=false

------
https://chatgpt.com/codex/tasks/task_e_68ce566671908326add25ad4caf419ee