### PR TITLE
Stabilize workspace settings modal sizing

### DIFF
--- a/components/modals/settings/SettingsCategorySidebar.tsx
+++ b/components/modals/settings/SettingsCategorySidebar.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { ChevronRightIcon } from '../../icons/ChevronRightIcon';
+import type { SettingsCategoryDefinition, SettingsCategoryId } from './categories';
+
+interface SettingsCategorySidebarProps {
+  categories: SettingsCategoryDefinition[];
+  activeCategory: SettingsCategoryId;
+  onSelect: (categoryId: SettingsCategoryId) => void;
+}
+
+/**
+ * Renders the desktop navigation list for switching between settings categories within the modal.
+ *
+ * @param props - Category metadata alongside the active selection and click handler.
+ * @returns Sidebar navigation markup that reflects the current selection state.
+ */
+export const SettingsCategorySidebar: React.FC<SettingsCategorySidebarProps> = ({
+  categories,
+  activeCategory,
+  onSelect,
+}) => (
+  <aside
+    className="hidden sm:flex sm:flex-col w-64 border-r border-border-color/80 bg-secondary/40 p-4 gap-3 overflow-y-auto"
+    role="tablist"
+    aria-orientation="vertical"
+  >
+    {categories.map(category => {
+      const isActive = category.id === activeCategory;
+      return (
+        <button
+          key={category.id}
+          type="button"
+          onClick={() => onSelect(category.id)}
+          id={`settings-tab-${category.id}`}
+          aria-selected={isActive}
+          aria-controls={`settings-panel-${category.id}`}
+          role="tab"
+          className={`w-full flex items-center justify-between gap-3 px-4 py-3 text-sm rounded-md border transition-colors duration-200 text-left ${
+            isActive
+              ? 'bg-primary/10 border-primary text-primary font-semibold shadow-sm'
+              : 'bg-surface/80 border-border-color text-text-secondary hover:text-text-primary'
+          }`}
+        >
+          <span className="flex-1">
+            <span className="block text-sm">{category.label}</span>
+            <span className="mt-1 block text-xs text-text-secondary">{category.description}</span>
+          </span>
+          <ChevronRightIcon
+            className={`w-4 h-4 transition-transform duration-150 ${isActive ? 'rotate-90 text-primary' : 'text-text-secondary'}`}
+          />
+        </button>
+      );
+    })}
+  </aside>
+);

--- a/components/modals/settings/SettingsCategoryTabs.tsx
+++ b/components/modals/settings/SettingsCategoryTabs.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { SettingsCategoryDefinition, SettingsCategoryId } from './categories';
+
+interface SettingsCategoryTabsProps {
+  categories: SettingsCategoryDefinition[];
+  activeCategory: SettingsCategoryId;
+  onSelect: (categoryId: SettingsCategoryId) => void;
+}
+
+/**
+ * Provides the mobile-friendly tab list for navigating between settings categories.
+ *
+ * @param props - Tab metadata, the currently selected category, and selection handler.
+ * @returns A responsive tab strip tailored for smaller viewports.
+ */
+export const SettingsCategoryTabs: React.FC<SettingsCategoryTabsProps> = ({
+  categories,
+  activeCategory,
+  onSelect,
+}) => (
+  <nav className="sm:hidden px-4 pb-4 flex flex-wrap gap-2 border-b border-border-color/80 bg-secondary/30">
+    {categories.map(category => {
+      const isActive = category.id === activeCategory;
+      return (
+        <button
+          key={category.id}
+          type="button"
+          onClick={() => onSelect(category.id)}
+          id={`settings-tab-${category.id}`}
+          className={`px-4 py-2 text-sm rounded-md border transition-colors duration-200 ${
+            isActive
+              ? 'bg-primary/10 border-primary text-primary font-semibold'
+              : 'bg-surface/80 border-border-color text-text-secondary hover:text-text-primary'
+          }`}
+        >
+          {category.label}
+        </button>
+      );
+    })}
+  </nav>
+);

--- a/components/modals/settings/categories.ts
+++ b/components/modals/settings/categories.ts
@@ -1,0 +1,30 @@
+export type SettingsCategoryId = 'global' | 'feature-overrides' | 'vector-store' | 'chat-presets';
+
+export interface SettingsCategoryDefinition {
+  id: SettingsCategoryId;
+  label: string;
+  description: string;
+}
+
+export const SETTINGS_CATEGORIES: SettingsCategoryDefinition[] = [
+  {
+    id: 'global',
+    label: 'Global Provider',
+    description: 'Set the default provider, model, and API credentials.',
+  },
+  {
+    id: 'feature-overrides',
+    label: 'Feature Overrides',
+    description: 'Customize providers and models on a per-feature basis.',
+  },
+  {
+    id: 'vector-store',
+    label: 'Vector Store',
+    description: 'Configure retrieval, embeddings, and vector database settings.',
+  },
+  {
+    id: 'chat-presets',
+    label: 'Chat Presets',
+    description: 'Manage saved prompts and default system instructions.',
+  },
+];


### PR DESCRIPTION
## Summary
- expand the workspace settings modal into a wider, full-height layout with contextual category content areas
- add reusable category metadata plus dedicated mobile tab and desktop sidebar navigation components for the settings modal
- keep the modal at a consistent size with a viewport-aware resizable frame and sharper themed styling updates

## Testing
- npm run typecheck *(fails: Cannot find type definition file for '@testing-library/jest-dom' and 'vitest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68ce7e8b87008326973863ebb304ca34