### PR TITLE
Refine workspace settings modal styling

### DIFF
--- a/components/modals/SettingsModal.tsx
+++ b/components/modals/SettingsModal.tsx
@@ -30,6 +30,31 @@ import {
   featurePreferenceCount,
   sanitizeVectorStoreSettings,
 } from './settings/helpers';
+import type { SettingsCategoryId } from './settings/categories';
+import { SETTINGS_CATEGORIES } from './settings/categories';
+import { SettingsCategoryTabs } from './settings/SettingsCategoryTabs';
+import { SettingsCategorySidebar } from './settings/SettingsCategorySidebar';
+
+const DEFAULT_MODAL_WIDTH = 1200;
+const DEFAULT_MODAL_HEIGHT = 720;
+const MIN_MODAL_WIDTH = 640;
+const MIN_MODAL_HEIGHT = 560;
+const MAX_MODAL_WIDTH = 1440;
+const MAX_MODAL_HEIGHT = 900;
+const VIEWPORT_MARGIN_X = 48;
+const VIEWPORT_MARGIN_Y = 64;
+const WORKSPACE_LAYOUT_WIDTH_KEY = 'ai_content_suite_layout_width';
+const MIN_WORKSPACE_CONTENT_WIDTH = 640;
+const MAX_WORKSPACE_CONTENT_WIDTH = 1440;
+const DEFAULT_WORKSPACE_LAYOUT_PERCENT = 70;
+const CHAT_HEIGHT_VIEWPORT_RATIO = 0.75;
+const WORKSPACE_SCROLLBAR_STYLE_ID = 'workspace-settings-scrollbar-theme';
+const WORKSPACE_SCROLLBAR_CLASS = 'workspace-settings-scrollbar';
+
+interface ModalSize {
+  width: number;
+  height: number;
+}
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -44,6 +69,12 @@ interface SettingsModalProps {
   onDeletePreset: (name: string) => void;
 }
 
+/**
+ * Presents the workspace settings experience inside a full-featured, resizable modal window.
+ *
+ * @param props - Collection of event handlers and the current workspace configuration state.
+ * @returns A rendered modal tree bound to the provided state values.
+ */
 export const SettingsModal: React.FC<SettingsModalProps> = ({
   isOpen,
   onClose,
@@ -62,7 +93,196 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const [modelsLoading, setModelsLoading] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
   const [selectedPreset, setSelectedPreset] = useState<string>('');
+  const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('global');
+  const [modalSize, setModalSize] = useState<ModalSize>({
+    width: DEFAULT_MODAL_WIDTH,
+    height: DEFAULT_MODAL_HEIGHT,
+  });
+  const [isResizing, setIsResizing] = useState(false);
   const loadRequestIdRef = useRef(0);
+  const initialSizeAppliedRef = useRef(false);
+  const resizeStateRef = useRef<{
+    startX: number;
+    startY: number;
+    startWidth: number;
+    startHeight: number;
+  } | null>(null);
+  const resizeHandlersRef = useRef<{
+    move: (event: PointerEvent) => void;
+    end: (event: PointerEvent) => void;
+  } | null>(null);
+  const previousBodyStylesRef = useRef<{ cursor: string; userSelect: string } | null>(null);
+
+  /**
+   * Constrains the requested modal dimensions so the window remains within the viewport bounds
+   * while respecting the design minimum and maximum breakpoints.
+   *
+   * @param width - Proposed modal width in pixels.
+   * @param height - Proposed modal height in pixels.
+   * @returns A sanitized pair of width and height values that fit the viewport.
+   */
+  const clampModalSize = useCallback(
+    (width: number, height: number): ModalSize => {
+      if (typeof window === 'undefined') {
+        return { width, height };
+      }
+
+      const availableWidth = Math.max(
+        window.innerWidth - VIEWPORT_MARGIN_X,
+        Math.min(window.innerWidth, 320),
+      );
+      const availableHeight = Math.max(
+        window.innerHeight - VIEWPORT_MARGIN_Y,
+        Math.min(window.innerHeight, 360),
+      );
+      const minWidth = Math.min(MIN_MODAL_WIDTH, availableWidth);
+      const minHeight = Math.min(MIN_MODAL_HEIGHT, availableHeight);
+      const maxWidth = Math.min(MAX_MODAL_WIDTH, availableWidth);
+      const maxHeight = Math.min(MAX_MODAL_HEIGHT, availableHeight);
+
+      const clampedWidth = Math.min(Math.max(width, minWidth), maxWidth);
+      const clampedHeight = Math.min(Math.max(height, minHeight), maxHeight);
+
+      return { width: clampedWidth, height: clampedHeight };
+    },
+    [],
+  );
+
+  /**
+   * Ensures the workspace-themed scrollbar styling is present so modal scroll regions
+   * inherit the darker treatment that matches the rest of the application chrome.
+   */
+  const ensureScrollbarTheme = useCallback(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    if (document.getElementById(WORKSPACE_SCROLLBAR_STYLE_ID)) {
+      return;
+    }
+
+    const styleElement = document.createElement('style');
+    styleElement.id = WORKSPACE_SCROLLBAR_STYLE_ID;
+    styleElement.textContent = `
+.${WORKSPACE_SCROLLBAR_CLASS} {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.35 0 0 / 0.85) transparent;
+}
+.${WORKSPACE_SCROLLBAR_CLASS}::-webkit-scrollbar {
+  width: 12px;
+}
+.${WORKSPACE_SCROLLBAR_CLASS}::-webkit-scrollbar-track {
+  background: transparent;
+}
+.${WORKSPACE_SCROLLBAR_CLASS}::-webkit-scrollbar-thumb {
+  background-color: oklch(0.32 0 0 / 0.85);
+  border-radius: 9999px;
+  border: 2px solid oklch(0.18 0 0 / 0.8);
+}
+.${WORKSPACE_SCROLLBAR_CLASS}::-webkit-scrollbar-thumb:hover {
+  background-color: oklch(0.36 0 0 / 0.9);
+}
+`;
+    document.head.appendChild(styleElement);
+  }, []);
+
+  /**
+   * Cleans up any active resize gesture by removing event listeners and restoring the document
+   * cursor and selection styles.
+   */
+  const endResize = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handlers = resizeHandlersRef.current;
+    if (handlers) {
+      window.removeEventListener('pointermove', handlers.move);
+      window.removeEventListener('pointerup', handlers.end);
+      window.removeEventListener('pointercancel', handlers.end);
+      resizeHandlersRef.current = null;
+    }
+
+    resizeStateRef.current = null;
+    setIsResizing(false);
+
+    if (previousBodyStylesRef.current) {
+      document.body.style.cursor = previousBodyStylesRef.current.cursor;
+      document.body.style.userSelect = previousBodyStylesRef.current.userSelect;
+      previousBodyStylesRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Begins a resize gesture when the resize affordance is activated, tracking pointer movement
+   * to update the modal dimensions in real time.
+   *
+   * @param event - Pointer event emitted from the resize affordance.
+   */
+  const handleResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (typeof window === 'undefined') {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      resizeStateRef.current = {
+        startX: event.clientX,
+        startY: event.clientY,
+        startWidth: modalSize.width,
+        startHeight: modalSize.height,
+      };
+
+      setIsResizing(true);
+
+      if (!previousBodyStylesRef.current) {
+        previousBodyStylesRef.current = {
+          cursor: document.body.style.cursor,
+          userSelect: document.body.style.userSelect,
+        };
+      }
+
+      document.body.style.cursor = 'nwse-resize';
+      document.body.style.userSelect = 'none';
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const resizeState = resizeStateRef.current;
+        if (!resizeState) {
+          return;
+        }
+
+        const nextWidth = resizeState.startWidth + (moveEvent.clientX - resizeState.startX);
+        const nextHeight = resizeState.startHeight + (moveEvent.clientY - resizeState.startY);
+
+        setModalSize(prevSize => {
+          const constrainedSize = clampModalSize(nextWidth, nextHeight);
+          if (
+            constrainedSize.width === prevSize.width &&
+            constrainedSize.height === prevSize.height
+          ) {
+            return prevSize;
+          }
+          return constrainedSize;
+        });
+      };
+
+      const handlePointerEnd = () => {
+        endResize();
+      };
+
+      resizeHandlersRef.current = {
+        move: handlePointerMove,
+        end: handlePointerEnd,
+      };
+
+      window.addEventListener('pointermove', handlePointerMove);
+      window.addEventListener('pointerup', handlePointerEnd);
+      window.addEventListener('pointercancel', handlePointerEnd);
+    },
+    [clampModalSize, endResize, modalSize.height, modalSize.width],
+  );
 
   const updateVectorStore = useCallback((updater: (prev: VectorStoreSettings) => VectorStoreSettings) => {
     setEditedSettings(prev => {
@@ -159,16 +379,106 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
     }
   }, [onFetchModels, providers]);
 
-  useEffect(() => {
-    if (isOpen) {
-      setEditedSettings(withDefaults(currentSettings));
-      setEditedProviderSettings(providerSettings);
-      setModelOptions([]);
-      setModelsError(null);
-      setModelsLoading(false);
-      setSelectedPreset('');
+  /**
+   * Derives a modal footprint that mirrors the active workspace layout so each settings
+   * category opens at the same scale as the LLM chat experience.
+   */
+  const computeWorkspaceAlignedSize = useCallback((): ModalSize => {
+    if (typeof window === 'undefined') {
+      return clampModalSize(DEFAULT_MODAL_WIDTH, DEFAULT_MODAL_HEIGHT);
     }
-  }, [isOpen, currentSettings, providerSettings]);
+
+    const storedPercentRaw = Number(localStorage.getItem(WORKSPACE_LAYOUT_WIDTH_KEY));
+    const storedPercent = Number.isFinite(storedPercentRaw)
+      ? storedPercentRaw
+      : DEFAULT_WORKSPACE_LAYOUT_PERCENT;
+    const normalizedPercent = Math.min(Math.max(storedPercent, 0), 100);
+
+    const referenceWidth =
+      normalizedPercent >= 100
+        ? Math.min(MAX_WORKSPACE_CONTENT_WIDTH, window.innerWidth - VIEWPORT_MARGIN_X)
+        : MIN_WORKSPACE_CONTENT_WIDTH +
+          ((MAX_WORKSPACE_CONTENT_WIDTH - MIN_WORKSPACE_CONTENT_WIDTH) * normalizedPercent) / 100;
+
+    const referenceHeight = window.innerHeight * CHAT_HEIGHT_VIEWPORT_RATIO;
+
+    return clampModalSize(referenceWidth, referenceHeight);
+  }, [clampModalSize]);
+
+  useEffect(() => {
+    ensureScrollbarTheme();
+  }, [ensureScrollbarTheme]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      initialSizeAppliedRef.current = false;
+      return;
+    }
+
+    if (!initialSizeAppliedRef.current) {
+      const defaultSize = computeWorkspaceAlignedSize();
+      setModalSize(prevSize => {
+        if (prevSize.width === defaultSize.width && prevSize.height === defaultSize.height) {
+          return prevSize;
+        }
+        return defaultSize;
+      });
+      initialSizeAppliedRef.current = true;
+    } else {
+      setModalSize(prevSize => {
+        const constrainedSize = clampModalSize(prevSize.width, prevSize.height);
+        if (
+          constrainedSize.width === prevSize.width &&
+          constrainedSize.height === prevSize.height
+        ) {
+          return prevSize;
+        }
+        return constrainedSize;
+      });
+    }
+
+    setEditedSettings(withDefaults(currentSettings));
+    setEditedProviderSettings(providerSettings);
+    setModelOptions([]);
+    setModelsError(null);
+    setModelsLoading(false);
+    setSelectedPreset('');
+    setActiveCategory('global');
+  }, [
+    isOpen,
+    currentSettings,
+    providerSettings,
+    clampModalSize,
+    computeWorkspaceAlignedSize,
+  ]);
+
+  useEffect(() => {
+    if (!isOpen || typeof window === 'undefined') {
+      return;
+    }
+
+    const handleWindowResize = () => {
+      setModalSize(prevSize => {
+        const constrainedSize = clampModalSize(prevSize.width, prevSize.height);
+        if (
+          constrainedSize.width === prevSize.width &&
+          constrainedSize.height === prevSize.height
+        ) {
+          return prevSize;
+        }
+        return constrainedSize;
+      });
+    };
+
+    window.addEventListener('resize', handleWindowResize);
+    return () => {
+      window.removeEventListener('resize', handleWindowResize);
+    };
+  }, [isOpen, clampModalSize]);
+
+  useEffect(() => () => {
+    endResize();
+  }, [endResize]);
 
   useEffect(() => {
     if (isOpen) {
@@ -350,21 +660,12 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
   const embeddingRequiresApiKey = requiresEmbeddingApiKey(embeddingSettings.provider);
   const featurePreferences = editedProviderSettings.featureModelPreferences ?? {};
   const globalModelName = editedProviderSettings.selectedModel?.trim() || DEFAULT_PROVIDER_MODELS[editedProviderSettings.selectedProvider] || '';
+  const activeCategoryConfig = SETTINGS_CATEGORIES.find(category => category.id === activeCategory);
 
-  if (!isOpen) return null;
-
-  return (
-    <div
-      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50 transition-opacity duration-300 animate-fade-in-scale"
-      onClick={handleOverlayClick}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="workspace-settings-modal"
-    >
-      <div className="bg-surface rounded-xl shadow-2xl w-full max-w-4xl transform transition-all duration-300">
-        <SettingsModalHeader onClose={onClose} />
-
-        <div className="p-6 sm:p-8 space-y-8 max-h-[80vh] overflow-y-auto">
+  const renderCategoryContent = () => {
+    switch (activeCategory) {
+      case 'global':
+        return (
           <GlobalProviderSection
             providers={providers}
             selectedProviderId={editedProviderSettings.selectedProvider}
@@ -378,7 +679,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             onModelChange={handleModelInputChange}
             onRefreshModels={() => loadModels(editedProviderSettings.selectedProvider, selectedApiKey)}
           />
-
+        );
+      case 'feature-overrides':
+        return (
           <FeatureOverridesSection
             providers={providers}
             featurePreferences={featurePreferences}
@@ -388,7 +691,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             onToggleOverride={enableFeatureOverride}
             onUpdatePreference={updateFeaturePreference}
           />
-
+        );
+      case 'vector-store':
+        return (
           <VectorStoreSection
             vectorStoreSettings={vectorStoreSettings}
             embeddingEndpointPlaceholder={embeddingEndpointPlaceholder}
@@ -404,7 +709,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
             onEmbeddingApiKeyChange={handleEmbeddingApiKeyChange}
             onEmbeddingBaseUrlChange={handleEmbeddingBaseUrlChange}
           />
-
+        );
+      case 'chat-presets':
+        return (
           <ChatPresetsSection
             savedPrompts={savedPrompts}
             selectedPreset={selectedPreset}
@@ -416,9 +723,85 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
               if (selectedPreset) setSelectedPreset('');
             }}
           />
+        );
+      default:
+        return null;
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center p-4 sm:p-8 z-50 transition-opacity duration-300 animate-fade-in-scale"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="workspace-settings-modal"
+    >
+      <div
+        className={`relative flex flex-col overflow-hidden rounded-xl border border-border-color/80 bg-background/95 shadow-[0_40px_120px_-35px_rgba(0,0,0,0.85)] ${
+          isResizing ? 'select-none' : ''
+        }`}
+        style={{
+          width: modalSize.width,
+          height: modalSize.height,
+          minWidth: `min(${MIN_MODAL_WIDTH}px, calc(100vw - 3rem))`,
+          minHeight: `min(${MIN_MODAL_HEIGHT}px, calc(100vh - 4rem))`,
+          maxWidth: `min(${MAX_MODAL_WIDTH}px, calc(100vw - 2rem))`,
+          maxHeight: `min(${MAX_MODAL_HEIGHT}px, calc(100vh - 2rem))`,
+          transition: isResizing ? 'none' : 'width 220ms ease, height 220ms ease',
+        }}
+      >
+        <SettingsModalHeader onClose={onClose} />
+        <SettingsCategoryTabs
+          categories={SETTINGS_CATEGORIES}
+          activeCategory={activeCategory}
+          onSelect={categoryId => setActiveCategory(categoryId)}
+        />
+
+        <div className="flex flex-1 overflow-hidden">
+          <SettingsCategorySidebar
+            categories={SETTINGS_CATEGORIES}
+            activeCategory={activeCategory}
+            onSelect={categoryId => setActiveCategory(categoryId)}
+            scrollbarClassName={WORKSPACE_SCROLLBAR_CLASS}
+          />
+
+          <div
+            className="relative flex-1 bg-background/80 sm:border-l sm:border-border-color/70"
+            role="tabpanel"
+            id={`settings-panel-${activeCategory}`}
+            aria-labelledby={`settings-tab-${activeCategory}`}
+          >
+            <div
+              key={activeCategory}
+              className={`h-full overflow-y-auto ${WORKSPACE_SCROLLBAR_CLASS} px-6 py-6 sm:px-9 sm:py-8 transition-opacity duration-200 ease-out`}
+            >
+              {activeCategoryConfig && (
+                <div className="mb-6 hidden sm:block">
+                  <h3 className="text-lg font-semibold text-text-primary">{activeCategoryConfig.label}</h3>
+                  <p className="mt-1 text-sm text-text-secondary/80">{activeCategoryConfig.description}</p>
+                </div>
+              )}
+              {renderCategoryContent()}
+            </div>
+          </div>
         </div>
 
         <SettingsModalFooter onClose={onClose} onSave={handleSave} onSaveAsPreset={handleSaveAsPreset} />
+        <div
+          className="absolute bottom-0 right-0 p-3 cursor-nwse-resize text-text-secondary/70 hover:text-primary transition-colors duration-150"
+          onPointerDown={handleResizePointerDown}
+          role="presentation"
+          aria-hidden="true"
+        >
+          <div
+            className={`pointer-events-none h-3 w-3 border-b border-r border-current ${
+              isResizing ? 'opacity-100' : 'opacity-70'
+            }`}
+          />
+        </div>
       </div>
     </div>
   );

--- a/components/modals/settings/SettingsCategorySidebar.tsx
+++ b/components/modals/settings/SettingsCategorySidebar.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { ChevronRightIcon } from '../../icons/ChevronRightIcon';
+import type { SettingsCategoryDefinition, SettingsCategoryId } from './categories';
+
+interface SettingsCategorySidebarProps {
+  categories: SettingsCategoryDefinition[];
+  activeCategory: SettingsCategoryId;
+  onSelect: (categoryId: SettingsCategoryId) => void;
+  scrollbarClassName?: string;
+}
+
+/**
+ * Renders the desktop navigation list for switching between settings categories within the modal.
+ *
+ * @param props - Category metadata, the active selection, and optional theming classes for scroll treatment.
+ * @returns Sidebar navigation markup that reflects the current selection state.
+ */
+export const SettingsCategorySidebar: React.FC<SettingsCategorySidebarProps> = ({
+  categories,
+  activeCategory,
+  onSelect,
+  scrollbarClassName,
+}) => {
+  const baseClassName =
+    'hidden sm:flex sm:flex-col w-72 border-r border-border-color/70 bg-background/80 p-5 gap-3 overflow-y-auto pr-3';
+  const composedClassName = scrollbarClassName ? `${baseClassName} ${scrollbarClassName}` : baseClassName;
+
+  return (
+    <aside className={composedClassName} role="tablist" aria-orientation="vertical">
+      {categories.map(category => {
+        const isActive = category.id === activeCategory;
+        const buttonBaseClass =
+          'w-full flex items-center justify-between gap-3 px-4 py-3 text-sm rounded-lg border transition-colors duration-200 text-left';
+        const buttonStateClass = isActive
+          ? 'bg-primary/15 border-primary/60 text-primary font-semibold'
+          : 'bg-background/70 border-border-color/70 text-text-secondary hover:text-text-primary hover:border-border-color/50 hover:bg-background/80';
+
+        return (
+          <button
+            key={category.id}
+            type="button"
+            onClick={() => onSelect(category.id)}
+            id={`settings-tab-${category.id}`}
+            aria-selected={isActive}
+            aria-controls={`settings-panel-${category.id}`}
+            role="tab"
+            className={`${buttonBaseClass} ${buttonStateClass}`}
+          >
+            <span className="flex-1">
+              <span className="block text-sm text-text-primary/95">{category.label}</span>
+              <span className="mt-1 block text-xs text-text-secondary/80">{category.description}</span>
+            </span>
+            <ChevronRightIcon
+              className={`w-4 h-4 transition-transform duration-150 ${
+                isActive ? 'rotate-90 text-primary' : 'text-text-secondary/80'
+              }`}
+            />
+          </button>
+        );
+      })}
+    </aside>
+  );
+};

--- a/components/modals/settings/SettingsCategoryTabs.tsx
+++ b/components/modals/settings/SettingsCategoryTabs.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { SettingsCategoryDefinition, SettingsCategoryId } from './categories';
+
+interface SettingsCategoryTabsProps {
+  categories: SettingsCategoryDefinition[];
+  activeCategory: SettingsCategoryId;
+  onSelect: (categoryId: SettingsCategoryId) => void;
+}
+
+/**
+ * Provides the mobile-friendly tab list for navigating between settings categories.
+ *
+ * @param props - Tab metadata, the currently selected category, and selection handler.
+ * @returns A responsive tab strip tailored for smaller viewports.
+ */
+export const SettingsCategoryTabs: React.FC<SettingsCategoryTabsProps> = ({
+  categories,
+  activeCategory,
+  onSelect,
+}) => (
+  <nav className="sm:hidden px-4 pb-4 flex flex-wrap gap-2 border-b border-border-color/70 bg-background/80 backdrop-blur-sm">
+    {categories.map(category => {
+      const isActive = category.id === activeCategory;
+      return (
+        <button
+          key={category.id}
+          type="button"
+          onClick={() => onSelect(category.id)}
+          id={`settings-tab-${category.id}`}
+          className={`px-4 py-2 text-sm rounded-lg border transition-colors duration-200 ${
+            isActive
+              ? 'bg-primary/15 border-primary/60 text-primary font-semibold'
+              : 'bg-background/70 border-border-color/70 text-text-secondary hover:text-text-primary hover:border-border-color/50 hover:bg-background/80'
+          }`}
+        >
+          {category.label}
+        </button>
+      );
+    })}
+  </nav>
+);

--- a/components/modals/settings/categories.ts
+++ b/components/modals/settings/categories.ts
@@ -1,0 +1,30 @@
+export type SettingsCategoryId = 'global' | 'feature-overrides' | 'vector-store' | 'chat-presets';
+
+export interface SettingsCategoryDefinition {
+  id: SettingsCategoryId;
+  label: string;
+  description: string;
+}
+
+export const SETTINGS_CATEGORIES: SettingsCategoryDefinition[] = [
+  {
+    id: 'global',
+    label: 'Global Provider',
+    description: 'Set the default provider, model, and API credentials.',
+  },
+  {
+    id: 'feature-overrides',
+    label: 'Feature Overrides',
+    description: 'Customize providers and models on a per-feature basis.',
+  },
+  {
+    id: 'vector-store',
+    label: 'Vector Store',
+    description: 'Configure retrieval, embeddings, and vector database settings.',
+  },
+  {
+    id: 'chat-presets',
+    label: 'Chat Presets',
+    description: 'Manage saved prompts and default system instructions.',
+  },
+];


### PR DESCRIPTION
## Summary
- expand the workspace settings modal into a wider, chat-aligned layout with contextual category content areas
- add reusable category metadata plus dedicated mobile tab and desktop sidebar navigation components for the settings modal
- keep the modal at a consistent size with a workspace-aware footprint, darker chrome, and themed scrollbars that match the rest of the suite

## Testing
- npm run typecheck *(fails: Cannot find type definition file for '@testing-library/jest-dom' and 'vitest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68ce7e8b87008326973863ebb304ca34