### PR TITLE
Fix feature panel layout regression

### DIFF
--- a/components/layouts/ChatInterface.tsx
+++ b/components/layouts/ChatInterface.tsx
@@ -20,6 +20,11 @@ export interface ChatInterfaceProps {
     onOpenSettings: () => void;
 }
 
+/**
+ * Presents the live chat workspace including transcript history, drag-and-drop file
+ * attachments, and the streaming input form. The component expects sizing to be managed
+ * by the parent feature panel and therefore stretches to fill the available height.
+ */
 export const ChatInterface: React.FC<ChatInterfaceProps> = ({
     history, isStreaming,
     chatInput, onChatInputChange,
@@ -51,7 +56,7 @@ export const ChatInterface: React.FC<ChatInterfaceProps> = ({
 
     return (
         <div
-            className={`relative animate-fade-in-scale flex flex-col flex-1 min-h-0 transition-all duration-300 rounded-lg ${isDraggingOver ? 'ring-4 ring-primary ring-offset-4 ring-offset-surface' : ''}`}
+            className={`relative animate-fade-in-scale flex h-full flex-col flex-1 min-h-0 transition-shadow duration-200 rounded-lg ${isDraggingOver ? 'ring-4 ring-primary ring-offset-4 ring-offset-surface' : ''}`}
             onDragEnter={handleDragEnter} onDragLeave={handleDragLeave} onDragOver={handleDragOver} onDrop={handleDrop}
         >
             {isDraggingOver && (

--- a/components/layouts/FeaturePanel.tsx
+++ b/components/layouts/FeaturePanel.tsx
@@ -1,0 +1,81 @@
+import React, { type CSSProperties, type ReactNode } from 'react';
+
+interface FeaturePanelProps {
+  /**
+   * Primary content rendered within the standardized feature panel. The node should
+   * stretch to fill the available space and manage any internal scrolling behavior.
+   */
+  children: ReactNode;
+  /**
+   * Optional footer region rendered at the bottom of the panel. When provided the panel
+   * reserves vertical space using the supplied footer height token so the overall
+   * bounding box remains stable across feature switches.
+   */
+  footer?: ReactNode;
+  /**
+   * Explicit footer height token. Defaults to the shared footer reserve size when omitted.
+   */
+  footerHeight?: string;
+  /**
+   * Additional class names applied to the outer panel container for styling overrides.
+   */
+  className?: string;
+  /**
+   * Optional class names merged onto the scrollable content container inside the panel.
+   */
+  contentClassName?: string;
+}
+
+type FeaturePanelStyle = CSSProperties & {
+  '--feature-panel-footer-height': string;
+};
+
+/**
+ * Establishes a shared, token-driven bounding box for feature tab content. The wrapper
+ * consumes layout tokens defined on the workspace card to keep every tab aligned with
+ * the LLM chat reference dimensions while delegating scrolling to the inner content
+ * region. An optional footer channel is provided for mode-specific controls such as
+ * submit buttons or progress indicators without affecting the panel height.
+ */
+export const FeaturePanel: React.FC<FeaturePanelProps> = ({
+  children,
+  footer,
+  footerHeight,
+  className,
+  contentClassName,
+}) => {
+  const resolvedFooterHeight = footer
+    ? footerHeight ?? 'var(--feature-panel-footer-default)'
+    : '0px';
+
+  const panelStyle: FeaturePanelStyle = {
+    '--feature-panel-footer-height': resolvedFooterHeight,
+  };
+
+  return (
+    <section
+      data-testid="feature-panel"
+      className={`feature-panel relative flex min-h-0 flex-1 flex-col overflow-hidden ${className ?? ''}`.trim()}
+      style={panelStyle}
+    >
+      <div
+        className={`feature-panel__content flex min-h-0 flex-1 flex-col overflow-hidden ${
+          contentClassName ?? ''
+        }`.trim()}
+      >
+        {children}
+      </div>
+      {footer ? (
+        <div
+          className="feature-panel__footer flex w-full shrink-0 items-stretch"
+          style={{
+            height: resolvedFooterHeight,
+            minHeight: resolvedFooterHeight,
+          }}
+        >
+          {footer}
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/components/layouts/MainForm.tsx
+++ b/components/layouts/MainForm.tsx
@@ -98,7 +98,7 @@ export const MainForm: React.FC<MainFormProps> = (props) => {
     }
 
     return (
-        <div className="animate-fade-in-scale flex flex-col flex-1 min-h-0 gap-6">
+        <div className="animate-fade-in-scale flex h-full flex-col flex-1 min-h-0 gap-6">
             <div className="flex-1 min-h-0 overflow-y-auto space-y-6 pr-1">
                 {renderControls()}
             </div>

--- a/components/layouts/WorkspaceLayout.tsx
+++ b/components/layouts/WorkspaceLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type CSSProperties } from 'react';
 import type { Mode, ProcessingError } from '../../types';
 import type { AppState, ProgressUpdate } from '../../types';
 import { Sidebar } from './Sidebar';
@@ -9,8 +9,13 @@ import { SubmitButton } from '../ui/SubmitButton';
 import { StopButton } from '../ui/StopButton';
 import { ResultsViewer, ResultsViewerProps } from './ResultsViewer';
 import { ProgressBar } from '../ui/ProgressBar';
+import { FeaturePanel } from './FeaturePanel';
 import { DESCRIPTION_TEXT, TABS } from '../../constants/uiConstants';
-import { WORKSPACE_CARD_MIN_HEIGHT } from '../../config/uiConfig';
+import {
+  FEATURE_PANEL_DEFAULT_FOOTER_HEIGHT,
+  FEATURE_PANEL_PROCESSING_FOOTER_HEIGHT,
+  WORKSPACE_CARD_MIN_HEIGHT,
+} from '../../config/uiConfig';
 import { XCircleIcon } from '../icons/XCircleIcon';
 
 interface WorkspaceLayoutProps {
@@ -80,6 +85,59 @@ export const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({
 }) => {
   const description = DESCRIPTION_TEXT[activeMode];
   const isProcessing = appState === 'processing';
+  const workspaceCardStyle = {
+    minHeight: WORKSPACE_CARD_MIN_HEIGHT,
+    maxHeight: WORKSPACE_CARD_MIN_HEIGHT,
+    height: WORKSPACE_CARD_MIN_HEIGHT,
+    '--feature-panel-footer-default': FEATURE_PANEL_DEFAULT_FOOTER_HEIGHT,
+    '--feature-panel-footer-processing': FEATURE_PANEL_PROCESSING_FOOTER_HEIGHT,
+  } as CSSProperties & {
+    '--feature-panel-footer-default': string;
+    '--feature-panel-footer-processing': string;
+  };
+
+  const featurePanelContent = showChat && chatProps
+    ? <ChatInterface {...chatProps} />
+    : showMainForm && mainFormProps
+      ? <MainForm {...mainFormProps} />
+      : null;
+
+  const shouldShowResultsInPanel = showResults && !!resultsProps;
+
+  const panelContent = shouldShowResultsInPanel && resultsProps ? (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pr-1">
+      <ResultsViewer {...resultsProps} />
+    </div>
+  ) : (
+    featurePanelContent
+  );
+
+  const panelFooter = isProcessing
+    ? (
+        <div className="flex h-full w-full flex-col justify-center gap-4">
+          <ProgressBar progress={progress} />
+          <StopButton onClick={onStop} wrapperClassName="text-center" />
+        </div>
+      )
+    : showSubmitButton
+      ? (
+          <div className="flex h-full w-full items-center justify-center">
+            <SubmitButton
+              onClick={onSubmit}
+              disabled={isProcessing}
+              appState={appState}
+              buttonText={buttonText}
+              wrapperClassName="text-center"
+            />
+          </div>
+        )
+      : null;
+
+  const panelFooterHeight = isProcessing
+    ? 'var(--feature-panel-footer-processing)'
+    : showSubmitButton
+      ? 'var(--feature-panel-footer-default)'
+      : '0px';
 
   return (
     <div className="relative min-h-screen flex bg-transparent text-text-primary">
@@ -140,11 +198,7 @@ export const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({
             <div
               data-testid="workspace-card"
               className="bg-surface/95 shadow-2xl rounded-2xl animate-breathing-glow p-6 sm:p-8 backdrop-blur-sm flex flex-col min-h-0 overflow-hidden"
-              style={{
-                minHeight: WORKSPACE_CARD_MIN_HEIGHT,
-                maxHeight: WORKSPACE_CARD_MIN_HEIGHT,
-                height: WORKSPACE_CARD_MIN_HEIGHT,
-              }}
+              style={workspaceCardStyle}
             >
               <header className="mb-6 text-center">
                 <h2 className="text-3xl sm:text-4xl font-bold text-text-primary">AI Content Suite</h2>
@@ -174,26 +228,13 @@ export const WorkspaceLayout: React.FC<WorkspaceLayoutProps> = ({
                 </div>
               </div>
 
-              <div className="flex flex-col gap-6 flex-1 min-h-0">
-                {showChat && chatProps ? (
-                  <ChatInterface {...chatProps} />
-                ) : showMainForm && mainFormProps ? (
-                  <MainForm {...mainFormProps} />
-                ) : null}
-
-                {showSubmitButton && (
-                  <SubmitButton onClick={onSubmit} disabled={isProcessing} appState={appState} buttonText={buttonText} />
-                )}
-
-                {isProcessing && (
-                  <div className="flex flex-col gap-4">
-                    <ProgressBar progress={progress} />
-                    <StopButton onClick={onStop} />
-                  </div>
-                )}
-              </div>
-
-              {showResults && resultsProps && <ResultsViewer {...resultsProps} />}
+              <FeaturePanel
+                footer={panelFooter}
+                footerHeight={panelFooterHeight}
+                className="flex-1"
+              >
+                {panelContent}
+              </FeaturePanel>
 
               {showError && error && (
                 <div className="mt-8 p-4 bg-red-900 border border-red-700 rounded-lg text-red-100 animate-fade-in-scale" role="alert">

--- a/components/modals/SettingsModal.tsx
+++ b/components/modals/SettingsModal.tsx
@@ -798,6 +798,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
       aria-labelledby="workspace-settings-modal"
     >
       <div
+        data-testid="settings-modal-window"
         className={`relative flex flex-col overflow-hidden rounded-2xl bg-background/95 border border-border-color shadow-[0_48px_140px_-40px_rgba(0,0,0,0.85)] backdrop-blur-md ${
           isResizing ? 'select-none' : ''
         }`}
@@ -808,7 +809,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({
           minHeight: `min(${MIN_MODAL_HEIGHT}px, calc(100vh - 4rem))`,
           maxWidth: `min(${MAX_MODAL_WIDTH}px, calc(100vw - 2rem))`,
           maxHeight: `min(${MAX_MODAL_HEIGHT}px, calc(100vh - 2rem))`,
-          transition: isResizing ? 'none' : 'width 220ms ease, height 220ms ease',
+          transition: isResizing ? 'none' : 'box-shadow 220ms ease, opacity 220ms ease',
         }}
       >
         <SettingsModalHeader onClose={onClose} />

--- a/components/ui/StopButton.tsx
+++ b/components/ui/StopButton.tsx
@@ -5,11 +5,17 @@ import { XCircleIcon } from '../icons/XCircleIcon';
 
 interface StopButtonProps {
     onClick: () => void;
+    wrapperClassName?: string;
 }
 
-export const StopButton: React.FC<StopButtonProps> = ({ onClick }) => {
+/**
+ * Provides a destructive action control that stops the active processing run. The wrapper
+ * class can be customized by callers so the button integrates into reserved layout areas
+ * without introducing additional spacing utilities.
+ */
+export const StopButton: React.FC<StopButtonProps> = ({ onClick, wrapperClassName = 'mt-4 text-center' }) => {
     return (
-        <div className="mt-4 text-center">
+        <div className={wrapperClassName}>
             <button
                 onClick={onClick}
                 className="px-6 py-2 bg-destructive text-destructive-foreground font-semibold rounded-lg hover:bg-destructive/80 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-surface flex items-center justify-center gap-2 mx-auto"

--- a/components/ui/SubmitButton.tsx
+++ b/components/ui/SubmitButton.tsx
@@ -8,11 +8,17 @@ interface SubmitButtonProps {
     disabled: boolean;
     appState: AppState;
     buttonText: string;
+    wrapperClassName?: string;
 }
 
-export const SubmitButton: React.FC<SubmitButtonProps> = ({ onClick, disabled, appState, buttonText }) => {
+/**
+ * Renders the primary call-to-action button used by non-chat feature tabs. Consumers can
+ * optionally override the wrapper class to integrate the button into custom layout
+ * containers without duplicating its styling logic.
+ */
+export const SubmitButton: React.FC<SubmitButtonProps> = ({ onClick, disabled, appState, buttonText, wrapperClassName = 'mt-6 text-center' }) => {
     return (
-        <div className="mt-6 text-center">
+        <div className={wrapperClassName}>
             <button
                 onClick={onClick}
                 disabled={disabled}

--- a/config/uiConfig.ts
+++ b/config/uiConfig.ts
@@ -38,6 +38,10 @@ export const UI_DIMENSIONS = {
     viewerMaxHeightMaxPx: 960,
     heightViewportRatio: 0.75,
   },
+  featurePanel: {
+    footerDefaultRem: 5.5,
+    footerProcessingRem: 12,
+  },
   settingsModal: {
     defaultWidth: 1360,
     defaultHeight: 840,
@@ -80,3 +84,15 @@ export const CHAT_HEIGHT_CLAMP = viewportClamp(
   UI_DIMENSIONS.chat.heightViewportRatio,
   UI_DIMENSIONS.settingsModal.maxHeight,
 );
+
+/**
+ * Default footer reserve height used when a tab renders bottom-aligned actions such as
+ * submit buttons. Expressed as a rem-based token to ensure proportional spacing.
+ */
+export const FEATURE_PANEL_DEFAULT_FOOTER_HEIGHT = `${UI_DIMENSIONS.featurePanel.footerDefaultRem}rem`;
+
+/**
+ * Taller footer reserve for streaming or progress states that require additional
+ * vertical space without collapsing the main content area.
+ */
+export const FEATURE_PANEL_PROCESSING_FOOTER_HEIGHT = `${UI_DIMENSIONS.featurePanel.footerProcessingRem}rem`;

--- a/tests/WorkspaceLayout.test.tsx
+++ b/tests/WorkspaceLayout.test.tsx
@@ -1,11 +1,24 @@
 /* @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { WorkspaceLayout } from '../components/layouts/WorkspaceLayout';
-import { WORKSPACE_CARD_MIN_HEIGHT } from '../config/uiConfig';
-import type { AppState, Mode, ProgressUpdate } from '../types';
+import {
+  FEATURE_PANEL_DEFAULT_FOOTER_HEIGHT,
+  FEATURE_PANEL_PROCESSING_FOOTER_HEIGHT,
+  WORKSPACE_CARD_MIN_HEIGHT,
+} from '../config/uiConfig';
+import type { AppState, Mode, ProcessedOutput, ProgressUpdate } from '../types';
+import type { ChatInterfaceProps } from '../components/layouts/ChatInterface';
+import type { MainFormProps } from '../components/layouts/MainForm';
+import {
+  INITIAL_AGENT_DESIGNER_SETTINGS,
+  INITIAL_PROMPT_ENHANCER_SETTINGS,
+  INITIAL_REASONING_SETTINGS,
+  INITIAL_REQUEST_SPLITTER_SETTINGS,
+  INITIAL_SCAFFOLDER_SETTINGS,
+} from '../constants';
 
 if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
   class MockResizeObserver {
@@ -26,9 +39,68 @@ if (typeof window !== 'undefined' && typeof window.HTMLElement !== 'undefined') 
 
 const noop = () => {};
 
+afterEach(() => {
+  cleanup();
+});
+
 const baseProgress: ProgressUpdate = {
   stage: 'Idle',
   percentage: 0,
+};
+
+const createChatProps = (): ChatInterfaceProps => ({
+  history: [],
+  isStreaming: false,
+  chatInput: '',
+  onChatInputChange: noop,
+  chatFiles: null,
+  onChatFilesChange: noop,
+  onSubmit: noop,
+  canSubmit: true,
+  onOpenSettings: noop,
+});
+
+const createMainFormProps = (): MainFormProps => ({
+  activeMode: 'technical',
+  currentFiles: null,
+  summaryFormat: 'default',
+  onSummaryFormatChange: noop,
+  summarySearchTerm: '',
+  onSummarySearchTermChange: noop,
+  summaryTextInput: '',
+  onSummaryTextChange: noop,
+  useHierarchical: false,
+  onUseHierarchicalChange: noop,
+  styleTarget: '',
+  onStyleTargetChange: noop,
+  rewriteStyle: '',
+  onRewriteStyleChange: noop,
+  rewriteInstructions: '',
+  onRewriteInstructionsChange: noop,
+  rewriteLength: 'medium',
+  onRewriteLengthChange: noop,
+  reasoningPrompt: '',
+  onReasoningPromptChange: noop,
+  reasoningSettings: JSON.parse(JSON.stringify(INITIAL_REASONING_SETTINGS)) as typeof INITIAL_REASONING_SETTINGS,
+  onReasoningSettingsChange: noop,
+  scaffolderPrompt: '',
+  onScaffolderPromptChange: noop,
+  scaffolderSettings: JSON.parse(JSON.stringify(INITIAL_SCAFFOLDER_SETTINGS)) as typeof INITIAL_SCAFFOLDER_SETTINGS,
+  onScaffolderSettingsChange: noop,
+  requestSplitterSpec: '',
+  onRequestSplitterSpecChange: noop,
+  requestSplitterSettings: JSON.parse(JSON.stringify(INITIAL_REQUEST_SPLITTER_SETTINGS)) as typeof INITIAL_REQUEST_SPLITTER_SETTINGS,
+  onRequestSplitterSettingsChange: noop,
+  promptEnhancerSettings: JSON.parse(JSON.stringify(INITIAL_PROMPT_ENHANCER_SETTINGS)) as typeof INITIAL_PROMPT_ENHANCER_SETTINGS,
+  onPromptEnhancerSettingsChange: noop,
+  agentDesignerSettings: JSON.parse(JSON.stringify(INITIAL_AGENT_DESIGNER_SETTINGS)) as typeof INITIAL_AGENT_DESIGNER_SETTINGS,
+  onAgentDesignerSettingsChange: noop,
+  onFileSelect: noop,
+});
+
+const processingProgress: ProgressUpdate = {
+  stage: 'Processing',
+  percentage: 42,
 };
 
 const baseProps = {
@@ -59,7 +131,9 @@ const baseProps = {
     onManageSettings: noop,
   },
   showChat: false,
+  chatProps: createChatProps(),
   showMainForm: false,
+  mainFormProps: createMainFormProps(),
   showSubmitButton: false,
   buttonText: 'Submit',
   onSubmit: noop,
@@ -79,5 +153,96 @@ describe('WorkspaceLayout', () => {
     expect(card).toHaveStyle({ minHeight: WORKSPACE_CARD_MIN_HEIGHT });
     expect(card).toHaveStyle({ maxHeight: WORKSPACE_CARD_MIN_HEIGHT });
     expect(card).toHaveStyle({ height: WORKSPACE_CARD_MIN_HEIGHT });
+    expect(card.style.getPropertyValue('--feature-panel-footer-default')).toBe(
+      FEATURE_PANEL_DEFAULT_FOOTER_HEIGHT,
+    );
+    expect(card.style.getPropertyValue('--feature-panel-footer-processing')).toBe(
+      FEATURE_PANEL_PROCESSING_FOOTER_HEIGHT,
+    );
+  });
+
+  it('updates the feature panel footer reserve across states', async () => {
+    const { rerender } = render(
+      <WorkspaceLayout
+        {...baseProps}
+        showChat
+        chatProps={createChatProps()}
+        showMainForm={false}
+      />,
+    );
+
+    const panel = await screen.findByTestId('feature-panel');
+    expect(panel.style.getPropertyValue('--feature-panel-footer-height')).toBe('0px');
+
+    rerender(
+      <WorkspaceLayout
+        {...baseProps}
+        showChat={false}
+        showMainForm
+        mainFormProps={createMainFormProps()}
+        showSubmitButton
+      />,
+    );
+
+    const panelWithSubmit = await screen.findByTestId('feature-panel');
+    expect(panelWithSubmit.style.getPropertyValue('--feature-panel-footer-height')).toBe(
+      'var(--feature-panel-footer-default)',
+    );
+
+    rerender(
+      <WorkspaceLayout
+        {...baseProps}
+        showChat={false}
+        showMainForm
+        mainFormProps={createMainFormProps()}
+        showSubmitButton={false}
+        appState={'processing' as AppState}
+        progress={processingProgress}
+      />,
+    );
+
+    const panelProcessing = await screen.findByTestId('feature-panel');
+    expect(panelProcessing.style.getPropertyValue('--feature-panel-footer-height')).toBe(
+      'var(--feature-panel-footer-processing)',
+    );
+  });
+
+  it('renders completion output within the feature panel content area', () => {
+    const promptEnhancerProcessedData = {
+      enhancedPromptMd: '# Example Prompt',
+      enhancedPromptJson: {
+        template: 'featureBuilder',
+        title: 'Example Prompt',
+      },
+    } as ProcessedOutput;
+
+    render(
+      <WorkspaceLayout
+        {...baseProps}
+        showChat={false}
+        showMainForm={false}
+        appState={'completed' as AppState}
+        showSubmitButton={false}
+        showResults
+        resultsProps={{
+          processedData: promptEnhancerProcessedData,
+          activeMode: 'promptEnhancer',
+          scaffolderSettings: JSON.parse(
+            JSON.stringify(INITIAL_SCAFFOLDER_SETTINGS),
+          ) as typeof INITIAL_SCAFFOLDER_SETTINGS,
+          onReset: noop,
+          onOpenReportModal: noop,
+          onDownloadReasoning: noop,
+          onDownloadScaffold: noop,
+          onDownloadRequestSplitter: noop,
+          onDownloadPromptEnhancer: noop,
+          onDownloadAgentDesigner: noop,
+        }}
+      />,
+    );
+
+    const panel = screen.getByTestId('feature-panel');
+    expect(panel).toHaveTextContent('Processing Complete!');
+    expect(screen.getByText('Processing Complete!')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- keep the workspace card at a fixed width/height and render results inside the shared feature panel so the panel no longer clips outputs when switching tabs
- let the FeaturePanel rely on flex sizing instead of a precomputed height while still reserving footer space for submit/stop controls
- update the workspace layout unit test and UI config constants to reflect the new sizing approach and guard against regressions

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cf2703801483268b3593636b465568